### PR TITLE
feat: define database schema and seed data

### DIFF
--- a/apps/api/docs/db-verification.md
+++ b/apps/api/docs/db-verification.md
@@ -1,0 +1,45 @@
+# Database Verification Guide
+
+These steps make it easy to assert that the SQLite schema, write-ahead logging, and seed data are in place. They are designed so future automation can copy/paste the commands verbatim.
+
+## 1. Apply the schema
+
+```bash
+pnpm --filter @stationery/api db:push
+```
+
+This command runs Drizzle's schema push and recreates the `customer_ledger` view.
+
+## 2. Seed reference data
+
+```bash
+pnpm --filter @stationery/api db:seed
+```
+
+The script truncates dependent tables (invoices, items, payments) before inserting 20 customers and 30 products.
+
+## 3. Confirm WAL mode
+
+```bash
+pnpm --filter @stationery/api exec sqlite3 stationery.sqlite "PRAGMA journal_mode;"
+```
+
+The output should be `wal`.
+
+## 4. Validate seed counts
+
+```bash
+pnpm --filter @stationery/api exec sqlite3 stationery.sqlite "SELECT COUNT(*) FROM customers;"
+pnpm --filter @stationery/api exec sqlite3 stationery.sqlite "SELECT COUNT(*) FROM products;"
+```
+
+Expect `20` customers and `30` products.
+
+## 5. Check the customer ledger view
+
+```bash
+pnpm --filter @stationery/api exec sqlite3 stationery.sqlite "SELECT name FROM sqlite_master WHERE type='view';"
+pnpm --filter @stationery/api exec sqlite3 stationery.sqlite "SELECT * FROM customer_ledger LIMIT 3;"
+```
+
+The first command should list `customer_ledger`. The second shows derived balances for seeded customers (initially `0`).

--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -1,6 +1,13 @@
+import 'dotenv/config';
 import type { Config } from 'drizzle-kit';
+
+const databaseUrl = process.env.DATABASE_URL ?? './stationery.sqlite';
 
 export default {
   schema: './src/db/schema.ts',
-  out: './drizzle'
+  out: './drizzle',
+  dialect: 'sqlite',
+  dbCredentials: {
+    url: databaseUrl
+  }
 } satisfies Config;

--- a/apps/api/drizzle/0000_slippery_onslaught.sql
+++ b/apps/api/drizzle/0000_slippery_onslaught.sql
@@ -1,0 +1,98 @@
+CREATE TABLE `customers` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`phone` text,
+	`email` text,
+	`address` text,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `health_checks` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`note` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `invoice_items` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`invoice_id` integer NOT NULL,
+	`product_id` integer NOT NULL,
+	`description` text,
+	`quantity` integer DEFAULT 1 NOT NULL,
+	`unit_price_cents` integer NOT NULL,
+	`line_total_cents` integer NOT NULL,
+	FOREIGN KEY (`invoice_id`) REFERENCES `invoices`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`product_id`) REFERENCES `products`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+CREATE TABLE `invoices` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`invoice_no` text NOT NULL,
+	`customer_id` integer NOT NULL,
+	`issue_date` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`sub_total_cents` integer DEFAULT 0 NOT NULL,
+	`discount_cents` integer DEFAULT 0 NOT NULL,
+	`tax_cents` integer DEFAULT 0 NOT NULL,
+	`grand_total_cents` integer DEFAULT 0 NOT NULL,
+	`status` text DEFAULT 'draft' NOT NULL,
+	`notes` text,
+	FOREIGN KEY (`customer_id`) REFERENCES `customers`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `payments` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`customer_id` integer NOT NULL,
+	`invoice_id` integer,
+	`amount_cents` integer NOT NULL,
+	`method` text DEFAULT 'cash' NOT NULL,
+	`paid_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`note` text,
+	FOREIGN KEY (`customer_id`) REFERENCES `customers`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`invoice_id`) REFERENCES `invoices`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE TABLE `products` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`sku` text NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`unit_price_cents` integer NOT NULL,
+	`stock_qty` integer DEFAULT 0 NOT NULL,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `customers_email_unique` ON `customers` (`email`);--> statement-breakpoint
+CREATE INDEX `customers_phone_idx` ON `customers` (`phone`);--> statement-breakpoint
+CREATE INDEX `invoice_items_invoice_idx` ON `invoice_items` (`invoice_id`);--> statement-breakpoint
+CREATE INDEX `invoice_items_product_idx` ON `invoice_items` (`product_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `invoices_invoice_no_unique` ON `invoices` (`invoice_no`);--> statement-breakpoint
+CREATE INDEX `invoices_customer_idx` ON `invoices` (`customer_id`);--> statement-breakpoint
+CREATE INDEX `invoices_status_idx` ON `invoices` (`status`);--> statement-breakpoint
+CREATE INDEX `payments_customer_idx` ON `payments` (`customer_id`);--> statement-breakpoint
+CREATE INDEX `payments_invoice_idx` ON `payments` (`invoice_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `products_sku_unique` ON `products` (`sku`);--> statement-breakpoint
+CREATE INDEX `products_name_idx` ON `products` (`name`);--> statement-breakpoint
+CREATE VIEW `customer_ledger` AS
+WITH invoice_totals AS (
+        SELECT
+                customer_id,
+                SUM(grand_total_cents) AS total_invoiced_cents
+        FROM invoices
+        WHERE status IN ('issued', 'partial')
+        GROUP BY customer_id
+),
+payment_totals AS (
+        SELECT
+                customer_id,
+                SUM(amount_cents) AS total_paid_cents
+        FROM payments
+        GROUP BY customer_id
+)
+SELECT
+        c.id AS customer_id,
+        c.name AS customer_name,
+        COALESCE(invoice_totals.total_invoiced_cents, 0) AS invoiced_cents,
+        COALESCE(payment_totals.total_paid_cents, 0) AS paid_cents,
+        COALESCE(invoice_totals.total_invoiced_cents, 0) - COALESCE(payment_totals.total_paid_cents, 0) AS balance_cents
+FROM customers c
+LEFT JOIN invoice_totals ON invoice_totals.customer_id = c.id
+LEFT JOIN payment_totals ON payment_totals.customer_id = c.id;--> statement-breakpoint

--- a/apps/api/drizzle/meta/0000_snapshot.json
+++ b/apps/api/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,503 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ce5e1a8a-3aeb-4076-a129-cabd643c119d",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "customers": {
+      "name": "customers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "customers_email_unique": {
+          "name": "customers_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "customers_phone_idx": {
+          "name": "customers_phone_idx",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "health_checks": {
+      "name": "health_checks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "invoice_items": {
+      "name": "invoice_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "unit_price_cents": {
+          "name": "unit_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line_total_cents": {
+          "name": "line_total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            "invoice_id"
+          ],
+          "isUnique": false
+        },
+        "invoice_items_product_idx": {
+          "name": "invoice_items_product_idx",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_items_product_id_products_id_fk": {
+          "name": "invoice_items_product_id_products_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "invoices": {
+      "name": "invoices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "invoice_no": {
+          "name": "invoice_no",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "sub_total_cents": {
+          "name": "sub_total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "discount_cents": {
+          "name": "discount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tax_cents": {
+          "name": "tax_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "grand_total_cents": {
+          "name": "grand_total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invoices_invoice_no_unique": {
+          "name": "invoices_invoice_no_unique",
+          "columns": [
+            "invoice_no"
+          ],
+          "isUnique": true
+        },
+        "invoices_customer_idx": {
+          "name": "invoices_customer_idx",
+          "columns": [
+            "customer_id"
+          ],
+          "isUnique": false
+        },
+        "invoices_status_idx": {
+          "name": "invoices_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invoices_customer_id_customers_id_fk": {
+          "name": "invoices_customer_id_customers_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "payments": {
+      "name": "payments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cash'"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "payments_customer_idx": {
+          "name": "payments_customer_idx",
+          "columns": [
+            "customer_id"
+          ],
+          "isUnique": false
+        },
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            "invoice_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "payments_customer_id_customers_id_fk": {
+          "name": "payments_customer_id_customers_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "products": {
+      "name": "products",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit_price_cents": {
+          "name": "unit_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stock_qty": {
+          "name": "stock_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "products_sku_unique": {
+          "name": "products_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "products_name_idx": {
+          "name": "products_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1759854444756,
+      "tag": "0000_slippery_onslaught",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,9 @@
     "test:watch": "vitest",
     "e2e": "playwright test",
     "lint": "eslint src --ext .ts",
-    "format": "prettier --write \"src/**/*.ts\""
+    "format": "prettier --write \"src/**/*.ts\"",
+    "db:push": "drizzle-kit push --config drizzle.config.ts && tsx src/db/ensure-ledger-view.ts",
+    "db:seed": "tsx src/db/seed.ts"
   },
   "dependencies": {
     "@stationery/shared": "workspace:*",
@@ -22,13 +24,14 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.43.1",
+    "@types/better-sqlite3": "^7.6.8",
     "@types/express": "4.17.21",
     "@types/node": "^20.12.7",
+    "dotenv": "16.4.5",
+    "drizzle-kit": "0.21.4",
     "supertest": "7.0.0",
     "tsx": "4.7.1",
     "typescript": "^5.4.5",
-    "vitest": "^1.5.2",
-    "drizzle-kit": "0.21.4",
-    "@types/better-sqlite3": "^7.6.8"
+    "vitest": "^1.5.2"
   }
 }

--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -1,15 +1,18 @@
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
-import { healthChecks } from './schema.js';
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
-const sqlite = new Database(':memory:');
+const databaseUrl = process.env.DATABASE_URL ?? join(process.cwd(), 'stationery.sqlite');
+const databaseDir = dirname(databaseUrl);
 
-sqlite.exec(`
-  CREATE TABLE IF NOT EXISTS health_checks (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    note TEXT NOT NULL
-  );
-`);
+mkdirSync(databaseDir, { recursive: true });
+
+export const sqlite = new Database(databaseUrl);
+
+sqlite.pragma('journal_mode = WAL');
+sqlite.pragma('foreign_keys = ON');
 
 export const db = drizzle(sqlite);
-export { healthChecks };
+
+export * from './schema.js';

--- a/apps/api/src/db/ensure-ledger-view.ts
+++ b/apps/api/src/db/ensure-ledger-view.ts
@@ -1,0 +1,35 @@
+import { sqlite } from './client.js';
+
+const viewSql = `
+DROP VIEW IF EXISTS customer_ledger;
+CREATE VIEW customer_ledger AS
+WITH invoice_totals AS (
+  SELECT
+    customer_id,
+    SUM(grand_total_cents) AS total_invoiced_cents
+  FROM invoices
+  WHERE status IN ('issued', 'partial')
+  GROUP BY customer_id
+),
+payment_totals AS (
+  SELECT
+    customer_id,
+    SUM(amount_cents) AS total_paid_cents
+  FROM payments
+  GROUP BY customer_id
+)
+SELECT
+  c.id AS customer_id,
+  c.name AS customer_name,
+  COALESCE(invoice_totals.total_invoiced_cents, 0) AS invoiced_cents,
+  COALESCE(payment_totals.total_paid_cents, 0) AS paid_cents,
+  COALESCE(invoice_totals.total_invoiced_cents, 0) -
+  COALESCE(payment_totals.total_paid_cents, 0) AS balance_cents
+FROM customers c
+LEFT JOIN invoice_totals ON invoice_totals.customer_id = c.id
+LEFT JOIN payment_totals ON payment_totals.customer_id = c.id;
+`;
+
+sqlite.exec(viewSql);
+console.log('Customer ledger view ensured.');
+sqlite.close();

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,6 +1,172 @@
-import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { relations, sql } from 'drizzle-orm';
+import {
+  index,
+  integer,
+  sqliteTable,
+  sqliteView,
+  text,
+  uniqueIndex
+} from 'drizzle-orm/sqlite-core';
+
+export const customers = sqliteTable(
+  'customers',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    name: text('name').notNull(),
+    phone: text('phone'),
+    email: text('email'),
+    address: text('address'),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`)
+  },
+  table => ({
+    emailUnique: uniqueIndex('customers_email_unique').on(table.email),
+    phoneIdx: index('customers_phone_idx').on(table.phone)
+  })
+);
+
+export const products = sqliteTable(
+  'products',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    sku: text('sku').notNull(),
+    name: text('name').notNull(),
+    description: text('description'),
+    unitPriceCents: integer('unit_price_cents').notNull(),
+    stockQty: integer('stock_qty').notNull().default(0),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`)
+  },
+  table => ({
+    skuUnique: uniqueIndex('products_sku_unique').on(table.sku),
+    nameIdx: index('products_name_idx').on(table.name)
+  })
+);
+
+export const invoices = sqliteTable(
+  'invoices',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    invoiceNo: text('invoice_no').notNull(),
+    customerId: integer('customer_id')
+      .notNull()
+      .references(() => customers.id, { onDelete: 'cascade' }),
+    issueDate: text('issue_date')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    subTotalCents: integer('sub_total_cents').notNull().default(0),
+    discountCents: integer('discount_cents').notNull().default(0),
+    taxCents: integer('tax_cents').notNull().default(0),
+    grandTotalCents: integer('grand_total_cents').notNull().default(0),
+    status: text('status', {
+      enum: ['draft', 'issued', 'partial', 'paid', 'void']
+    })
+      .notNull()
+      .default('draft'),
+    notes: text('notes')
+  },
+  table => ({
+    invoiceNoUnique: uniqueIndex('invoices_invoice_no_unique').on(table.invoiceNo),
+    customerIdx: index('invoices_customer_idx').on(table.customerId),
+    statusIdx: index('invoices_status_idx').on(table.status)
+  })
+);
+
+export const invoiceItems = sqliteTable(
+  'invoice_items',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    invoiceId: integer('invoice_id')
+      .notNull()
+      .references(() => invoices.id, { onDelete: 'cascade' }),
+    productId: integer('product_id')
+      .notNull()
+      .references(() => products.id, { onDelete: 'restrict' }),
+    description: text('description'),
+    quantity: integer('quantity').notNull().default(1),
+    unitPriceCents: integer('unit_price_cents').notNull(),
+    lineTotalCents: integer('line_total_cents').notNull()
+  },
+  table => ({
+    invoiceIdx: index('invoice_items_invoice_idx').on(table.invoiceId),
+    productIdx: index('invoice_items_product_idx').on(table.productId)
+  })
+);
+
+export const payments = sqliteTable(
+  'payments',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    customerId: integer('customer_id')
+      .notNull()
+      .references(() => customers.id, { onDelete: 'cascade' }),
+    invoiceId: integer('invoice_id').references(() => invoices.id, {
+      onDelete: 'set null'
+    }),
+    amountCents: integer('amount_cents').notNull(),
+    method: text('method').notNull().default('cash'),
+    paidAt: text('paid_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    note: text('note')
+  },
+  table => ({
+    customerIdx: index('payments_customer_idx').on(table.customerId),
+    invoiceIdx: index('payments_invoice_idx').on(table.invoiceId)
+  })
+);
 
 export const healthChecks = sqliteTable('health_checks', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   note: text('note').notNull()
 });
+
+export const customersRelations = relations(customers, ({ many }) => ({
+  invoices: many(invoices),
+  payments: many(payments)
+}));
+
+export const productsRelations = relations(products, ({ many }) => ({
+  items: many(invoiceItems)
+}));
+
+export const invoicesRelations = relations(invoices, ({ many, one }) => ({
+  customer: one(customers, {
+    fields: [invoices.customerId],
+    references: [customers.id]
+  }),
+  items: many(invoiceItems),
+  payments: many(payments)
+}));
+
+export const invoiceItemsRelations = relations(invoiceItems, ({ one }) => ({
+  invoice: one(invoices, {
+    fields: [invoiceItems.invoiceId],
+    references: [invoices.id]
+  }),
+  product: one(products, {
+    fields: [invoiceItems.productId],
+    references: [products.id]
+  })
+}));
+
+export const paymentsRelations = relations(payments, ({ one }) => ({
+  customer: one(customers, {
+    fields: [payments.customerId],
+    references: [customers.id]
+  }),
+  invoice: one(invoices, {
+    fields: [payments.invoiceId],
+    references: [invoices.id]
+  })
+}));
+
+export const customerLedgerView = sqliteView('customer_ledger', {
+  customerId: integer('customer_id').notNull(),
+  customerName: text('customer_name').notNull(),
+  invoicedCents: integer('invoiced_cents').notNull(),
+  paidCents: integer('paid_cents').notNull(),
+  balanceCents: integer('balance_cents').notNull()
+}).existing();

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -1,0 +1,367 @@
+import { db, customers, products, sqlite } from './client.js';
+
+const toCents = (value: number) => Math.round(value * 100);
+
+const customerSeed = [
+  {
+    name: 'Acme Office Supplies',
+    phone: '555-0100',
+    email: 'sales@acmeoffice.com',
+    address: '123 Paper St, Springfield'
+  },
+  {
+    name: 'Brightside Design Studio',
+    phone: '555-0101',
+    email: 'hello@brightside.design',
+    address: '48 Market Ave, Springfield'
+  },
+  {
+    name: 'Northwind Coworking',
+    phone: '555-0102',
+    email: 'team@northwindcowork.com',
+    address: '215 Harbor Blvd, Springfield'
+  },
+  {
+    name: 'Evergreen Architects',
+    phone: '555-0103',
+    email: 'contact@evergreenarch.com',
+    address: '9 Skyline Way, Springfield'
+  },
+  {
+    name: 'Blue Horizon Events',
+    phone: '555-0104',
+    email: 'events@bluehorizon.co',
+    address: '702 Riverside Dr, Springfield'
+  },
+  {
+    name: 'Craft & Clay Studio',
+    phone: '555-0105',
+    email: 'hi@craftandclay.studio',
+    address: '15 Artisan Ln, Springfield'
+  },
+  {
+    name: 'Fresh Grounds Cafe',
+    phone: '555-0106',
+    email: 'manager@freshgrounds.cafe',
+    address: '81 Cedar St, Springfield'
+  },
+  {
+    name: 'Greenline Landscaping',
+    phone: '555-0107',
+    email: 'office@greenline.land',
+    address: '578 Meadow Rd, Springfield'
+  },
+  {
+    name: 'Harbor Light B&B',
+    phone: '555-0108',
+    email: 'stay@harborlightbnb.com',
+    address: '2 Lighthouse Ct, Springfield'
+  },
+  {
+    name: 'Inkwell Publishing',
+    phone: '555-0109',
+    email: 'editors@inkwell.pub',
+    address: '431 Author Ave, Springfield'
+  },
+  {
+    name: 'Juniper Yoga Collective',
+    phone: '555-0110',
+    email: 'welcome@juniperyoga.co',
+    address: '77 Harmony St, Springfield'
+  },
+  {
+    name: 'Kindred Makers Market',
+    phone: '555-0111',
+    email: 'market@kindredmakers.com',
+    address: '301 Union Sq, Springfield'
+  },
+  {
+    name: 'Lakeview Dental',
+    phone: '555-0112',
+    email: 'frontdesk@lakeviewdental.com',
+    address: '560 Clear Lake Rd, Springfield'
+  },
+  {
+    name: 'Momentum Fitness Lab',
+    phone: '555-0113',
+    email: 'info@momentumlabs.fit',
+    address: '940 Powerhouse Dr, Springfield'
+  },
+  {
+    name: "Nova Children's Museum",
+    phone: '555-0114',
+    email: 'hello@novamuseum.org',
+    address: '18 Discovery Pl, Springfield'
+  },
+  {
+    name: 'Oak & Iron Furniture',
+    phone: '555-0115',
+    email: 'sales@oakandiron.shop',
+    address: '660 Workshop Rd, Springfield'
+  },
+  {
+    name: 'Parkside Community Theater',
+    phone: '555-0116',
+    email: 'stage@parksidetheater.org',
+    address: '40 Center Stage Ln, Springfield'
+  },
+  {
+    name: 'QuickFix IT Services',
+    phone: '555-0117',
+    email: 'support@quickfixit.pro',
+    address: '128 Circuit Rd, Springfield'
+  },
+  {
+    name: 'Riverstone Spa & Wellness',
+    phone: '555-0118',
+    email: 'care@riverstonespa.com',
+    address: '320 Tranquil Way, Springfield'
+  },
+  {
+    name: 'Summit Outdoor Gear',
+    phone: '555-0119',
+    email: 'orders@summitoutdoor.co',
+    address: '145 Ridge Trail, Springfield'
+  }
+];
+
+const productSeed = [
+  {
+    sku: 'PAPER-A4-80',
+    name: 'A4 Copy Paper 80gsm (Ream)',
+    description: 'Bright white office paper ideal for everyday printing.',
+    unitPriceCents: toCents(5.49),
+    stockQty: 180
+  },
+  {
+    sku: 'PAPER-A4-REC',
+    name: 'A4 Recycled Copy Paper (Ream)',
+    description: '100% recycled copy paper with smooth finish.',
+    unitPriceCents: toCents(5.99),
+    stockQty: 120
+  },
+  {
+    sku: 'NOTE-CLASSIC-A5',
+    name: 'Classic A5 Notebook',
+    description: 'Hardcover notebook with 240 ruled pages.',
+    unitPriceCents: toCents(12.95),
+    stockQty: 75
+  },
+  {
+    sku: 'NOTE-DOT-GRID',
+    name: 'Dot Grid Journal',
+    description: '160-page dotted journal perfect for bullet journaling.',
+    unitPriceCents: toCents(14.5),
+    stockQty: 60
+  },
+  {
+    sku: 'PEN-GEL-05-BK',
+    name: '0.5mm Gel Pen - Black (Pack of 12)',
+    description: 'Quick-dry gel ink with comfortable grip.',
+    unitPriceCents: toCents(11.25),
+    stockQty: 210
+  },
+  {
+    sku: 'PEN-GEL-05-COLOR',
+    name: '0.5mm Gel Pens - Assorted Colors (Pack of 12)',
+    description: 'Vibrant gel pens for notes and sketches.',
+    unitPriceCents: toCents(12.75),
+    stockQty: 155
+  },
+  {
+    sku: 'PEN-ROLLER-07-BL',
+    name: '0.7mm Rollerball Pen - Blue (Pack of 10)',
+    description: 'Smooth rollerball pens with archival-safe ink.',
+    unitPriceCents: toCents(9.95),
+    stockQty: 190
+  },
+  {
+    sku: 'MARK-HILITE-SET',
+    name: 'Pastel Highlighter Set (6 Pack)',
+    description: 'Soft pastel highlighters with chisel tips.',
+    unitPriceCents: toCents(8.5),
+    stockQty: 130
+  },
+  {
+    sku: 'MARK-PERM-SET',
+    name: 'Permanent Marker Set (8 Pack)',
+    description: 'Bold, low-odor permanent markers for labeling.',
+    unitPriceCents: toCents(10.5),
+    stockQty: 145
+  },
+  {
+    sku: 'ART-WATERCOLOR-24',
+    name: 'Watercolor Paint Set (24 Pan)',
+    description: 'Artist-grade watercolors in a travel-friendly tin.',
+    unitPriceCents: toCents(24.95),
+    stockQty: 48
+  },
+  {
+    sku: 'ART-SKETCH-SET',
+    name: 'Graphite Sketching Set',
+    description: 'Complete set with pencils, erasers, and blending tools.',
+    unitPriceCents: toCents(18.5),
+    stockQty: 52
+  },
+  {
+    sku: 'STAPLER-DESK',
+    name: 'Full-Strip Desk Stapler',
+    description: 'Metal stapler with 25-sheet capacity.',
+    unitPriceCents: toCents(13.75),
+    stockQty: 85
+  },
+  {
+    sku: 'STAPLES-5000',
+    name: 'Standard Staples (Box of 5000)',
+    description: 'Premium staples for smooth, jam-free stapling.',
+    unitPriceCents: toCents(4.5),
+    stockQty: 300
+  },
+  {
+    sku: 'FILE-FOLDER-SET',
+    name: 'File Folders - Assorted Colors (Pack of 20)',
+    description: 'Durable folders for organizing paperwork.',
+    unitPriceCents: toCents(9.25),
+    stockQty: 160
+  },
+  {
+    sku: 'FILE-BOX-LETTER',
+    name: 'Letter Size Storage Box',
+    description: 'Collapsible storage box with label window.',
+    unitPriceCents: toCents(7.75),
+    stockQty: 110
+  },
+  {
+    sku: 'BIND-NOTEBOOK-A4',
+    name: 'Wirebound Notebook A4',
+    description: 'College-ruled notebook with tear-out pages.',
+    unitPriceCents: toCents(6.5),
+    stockQty: 200
+  },
+  {
+    sku: 'BIND-PLAN-UNDATED',
+    name: 'Undated Weekly Planner',
+    description: 'Planner with perforated to-do lists and habit tracker.',
+    unitPriceCents: toCents(16.95),
+    stockQty: 70
+  },
+  {
+    sku: 'ADHESIVE-NOTES-SET',
+    name: 'Sticky Notes Variety Pack',
+    description: 'Multi-size sticky notes in bright colors.',
+    unitPriceCents: toCents(5.75),
+    stockQty: 230
+  },
+  {
+    sku: 'ADHESIVE-TAPE-DISP',
+    name: 'Crystal Clear Tape with Dispenser (4 Pack)',
+    description: 'Office tape rolls with weighted desktop dispenser.',
+    unitPriceCents: toCents(6.25),
+    stockQty: 190
+  },
+  {
+    sku: 'MAIL-BUBBLE-10',
+    name: 'Bubble Mailers 10x13 (Pack of 25)',
+    description: 'Padded mailers ideal for shipping small goods.',
+    unitPriceCents: toCents(11.95),
+    stockQty: 120
+  },
+  {
+    sku: 'MAIL-POLY-14',
+    name: 'Poly Mailers 14x19 (Pack of 50)',
+    description: 'Durable self-seal mailers for soft goods.',
+    unitPriceCents: toCents(13.5),
+    stockQty: 90
+  },
+  {
+    sku: 'ORG-DESK-TRAY',
+    name: 'Stackable Desk Tray',
+    description: 'Metal mesh tray for incoming documents.',
+    unitPriceCents: toCents(9.95),
+    stockQty: 95
+  },
+  {
+    sku: 'ORG-PEN-CUP',
+    name: 'Pen & Pencil Cup',
+    description: 'Weighted pen cup with felt base.',
+    unitPriceCents: toCents(4.95),
+    stockQty: 210
+  },
+  {
+    sku: 'ORG-CABLE-TIES',
+    name: 'Reusable Cable Ties (Pack of 20)',
+    description: 'Hook-and-loop ties to manage cables and cords.',
+    unitPriceCents: toCents(6.75),
+    stockQty: 150
+  },
+  {
+    sku: 'BOARD-WHITE-36',
+    name: 'Magnetic Whiteboard 36x24',
+    description: 'Dry erase board with mounting hardware.',
+    unitPriceCents: toCents(42.5),
+    stockQty: 34
+  },
+  {
+    sku: 'CLEAN-SPRAY',
+    name: 'Screen Cleaning Spray Kit',
+    description: 'Anti-static spray with microfiber cloth.',
+    unitPriceCents: toCents(8.95),
+    stockQty: 140
+  },
+  {
+    sku: 'CLEAN-WIPES-100',
+    name: 'Disinfecting Wipes (Tub of 100)',
+    description: 'Lemon-scented wipes safe for office surfaces.',
+    unitPriceCents: toCents(7.5),
+    stockQty: 170
+  },
+  {
+    sku: 'INK-HP-67XL-BK',
+    name: 'Ink Cartridge HP 67XL Black',
+    description: 'High-yield cartridge for HP DeskJet and ENVY series.',
+    unitPriceCents: toCents(38.99),
+    stockQty: 44
+  },
+  {
+    sku: 'TONER-BROTHER-TN760',
+    name: 'Toner Cartridge Brother TN-760',
+    description: 'High-yield toner compatible with Brother HL-L2350DW.',
+    unitPriceCents: toCents(74.95),
+    stockQty: 28
+  },
+  {
+    sku: 'CHAIR-MAT-HARD',
+    name: 'Chair Mat for Hard Floors',
+    description: 'Durable mat with anti-slip backing.',
+    unitPriceCents: toCents(49.95),
+    stockQty: 25
+  }
+];
+
+function seed() {
+  sqlite.exec(`
+    DELETE FROM invoice_items;
+    DELETE FROM payments;
+    DELETE FROM invoices;
+    DELETE FROM products;
+    DELETE FROM customers;
+  `);
+
+  db.transaction(tx => {
+    tx.insert(customers)
+      .values(customerSeed)
+      .onConflictDoNothing({ target: customers.email })
+      .run();
+
+    tx.insert(products)
+      .values(productSeed)
+      .onConflictDoNothing({ target: products.sku })
+      .run();
+  });
+
+  console.log(`Seeded ${customerSeed.length} customers and ${productSeed.length} products.`);
+}
+
+seed();
+
+sqlite.close();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@types/node':
         specifier: ^20.12.7
         version: 20.12.7
+      dotenv:
+        specifier: 16.4.5
+        version: 16.4.5
       drizzle-kit:
         specifier: 0.21.4
         version: 0.21.4
@@ -2020,6 +2023,10 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dotenv@16.4.5:
+    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
+    engines: {node: '>=12'}
 
   dreamopt@0.8.0:
     resolution: {integrity: sha512-vyJTp8+mC+G+5dfgsY+r3ckxlz+QMX40VjPQsZc5gxVAxLmi64TBoVkP54A/pRAXMXsbu2GMMBrZPxNv23waMg==}
@@ -5977,6 +5984,8 @@ snapshots:
       esutils: 2.0.3
 
   dom-accessibility-api@0.6.3: {}
+
+  dotenv@16.4.5: {}
 
   dreamopt@0.8.0:
     dependencies:


### PR DESCRIPTION
## Summary
- model customers, products, invoices, invoice items, payments, and the customer ledger view with Drizzle
- configure the SQLite client for WAL mode and add database push/seed scripts with migrations
- add a seed script that loads reference customers/products and document database verification steps

## Testing
- pnpm --filter @stationery/api db:push
- pnpm --filter @stationery/api db:seed
- pnpm --filter @stationery/api exec sqlite3 stationery.sqlite "PRAGMA journal_mode;"

------
https://chatgpt.com/codex/tasks/task_e_68e53dea9760832e8ad73d864eafc8fb