### PR TITLE
feat: finalize v1 api with docs

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,7 +20,9 @@
     "better-sqlite3": "9.4.5",
     "drizzle-orm": "0.30.10",
     "express": "4.19.2",
-    "zod": "3.23.8"
+    "swagger-ui-express": "5.0.1",
+    "zod": "3.23.8",
+    "@asteasolutions/zod-to-openapi": "7.1.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.43.1",

--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import * as schema from './schema.js';
 
 const databaseUrl = process.env.DATABASE_URL ?? join(process.cwd(), 'stationery.sqlite');
 const databaseDir = dirname(databaseUrl);
@@ -13,6 +14,6 @@ export const sqlite = new Database(databaseUrl);
 sqlite.pragma('journal_mode = WAL');
 sqlite.pragma('foreign_keys = ON');
 
-export const db = drizzle(sqlite);
+export const db = drizzle(sqlite, { schema });
 
 export * from './schema.js';

--- a/apps/api/src/docs/openapi.ts
+++ b/apps/api/src/docs/openapi.ts
@@ -1,0 +1,412 @@
+import { OpenAPIRegistry, OpenApiGeneratorV31, extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import {
+  customerCreateSchema,
+  customerLedgerSchema,
+  customerListQuerySchema,
+  customerListResponseSchema,
+  customerSchema,
+  duesReportSchema,
+  exampleCustomer,
+  exampleCustomerCreate,
+  exampleCustomerLedger,
+  exampleDuesReport,
+  exampleInvoice,
+  exampleInvoiceCreate,
+  examplePayment,
+  examplePaymentCreate,
+  exampleProduct,
+  exampleProductCreate,
+  exampleSalesReport,
+  healthCheckExample,
+  healthCheckSchema,
+  invoiceCreateSchema,
+  invoiceListQuerySchema,
+  invoiceListResponseSchema,
+  invoiceSchema,
+  paymentCreateSchema,
+  paymentListQuerySchema,
+  paymentListResponseSchema,
+  paymentSchema,
+  productCreateSchema,
+  productListQuerySchema,
+  productListResponseSchema,
+  productSchema,
+  salesReportQuerySchema,
+  salesReportSchema
+} from '@stationery/shared';
+import { z } from 'zod';
+
+extendZodWithOpenApi(z);
+
+const errorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  details: z.any().optional()
+});
+
+const registry = new OpenAPIRegistry();
+
+registry.register('Error', errorSchema);
+registry.register('HealthResponse', healthCheckSchema);
+registry.register('Customer', customerSchema);
+registry.register('CustomerCreate', customerCreateSchema);
+registry.register('CustomerListResponse', customerListResponseSchema);
+registry.register('CustomerLedger', customerLedgerSchema);
+registry.register('Product', productSchema);
+registry.register('ProductCreate', productCreateSchema);
+registry.register('ProductListResponse', productListResponseSchema);
+registry.register('Invoice', invoiceSchema);
+registry.register('InvoiceCreate', invoiceCreateSchema);
+registry.register('InvoiceListResponse', invoiceListResponseSchema);
+registry.register('Payment', paymentSchema);
+registry.register('PaymentCreate', paymentCreateSchema);
+registry.register('PaymentListResponse', paymentListResponseSchema);
+registry.register('DuesReport', duesReportSchema);
+registry.register('SalesReport', salesReportSchema);
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/health',
+  description: 'Health check for the API and dependencies',
+  responses: {
+    200: {
+      description: 'Service is healthy',
+      content: {
+        'application/json': {
+          schema: healthCheckSchema,
+          example: healthCheckExample
+        }
+      }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/customers',
+  description: 'List customers with optional search',
+  request: {
+    query: customerListQuerySchema
+  },
+  responses: {
+    200: {
+      description: 'List of customers',
+      content: {
+        'application/json': {
+          schema: customerListResponseSchema,
+          example: {
+            data: [exampleCustomer],
+            pagination: { total: 1, limit: 20, offset: 0 }
+          }
+        }
+      }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/v1/customers',
+  description: 'Create a customer',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: customerCreateSchema,
+          example: exampleCustomerCreate
+        }
+      }
+    }
+  },
+  responses: {
+    201: {
+      description: 'Created customer',
+      content: {
+        'application/json': {
+          schema: customerSchema,
+          example: exampleCustomer
+        }
+      }
+    },
+    400: { description: 'Validation error', content: { 'application/json': { schema: errorSchema } } }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/customers/{id}',
+  description: 'Fetch a customer by id',
+  request: {
+    params: z.object({ id: z.string() })
+  },
+  responses: {
+    200: {
+      description: 'Customer found',
+      content: { 'application/json': { schema: customerSchema, example: exampleCustomer } }
+    },
+    404: { description: 'Customer missing', content: { 'application/json': { schema: errorSchema } } }
+  }
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/api/v1/customers/{id}',
+  description: 'Update a customer',
+  request: {
+    params: z.object({ id: z.string() }),
+    body: {
+      content: {
+        'application/json': {
+          schema: customerCreateSchema.partial(),
+          example: { phone: '+1 555 987 6543' }
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Updated customer',
+      content: { 'application/json': { schema: customerSchema, example: exampleCustomer } }
+    },
+    404: { description: 'Customer missing', content: { 'application/json': { schema: errorSchema } } }
+  }
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/api/v1/customers/{id}',
+  description: 'Delete a customer',
+  request: {
+    params: z.object({ id: z.string() })
+  },
+  responses: {
+    204: { description: 'Deleted' },
+    404: { description: 'Customer missing', content: { 'application/json': { schema: errorSchema } } }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/customers/{id}/ledger',
+  description: 'Customer ledger summary',
+  request: {
+    params: z.object({ id: z.string() })
+  },
+  responses: {
+    200: {
+      description: 'Ledger summary',
+      content: { 'application/json': { schema: customerLedgerSchema, example: exampleCustomerLedger } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/products',
+  description: 'List products',
+  request: { query: productListQuerySchema },
+  responses: {
+    200: {
+      description: 'List of products',
+      content: {
+        'application/json': {
+          schema: productListResponseSchema,
+          example: { data: [exampleProduct], pagination: { total: 1, limit: 20, offset: 0 } }
+        }
+      }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/v1/products',
+  description: 'Create product',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: productCreateSchema,
+          example: exampleProductCreate
+        }
+      }
+    }
+  },
+  responses: {
+    201: {
+      description: 'Created product',
+      content: { 'application/json': { schema: productSchema, example: exampleProduct } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/products/{id}',
+  description: 'Product details',
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: {
+      description: 'Product info',
+      content: { 'application/json': { schema: productSchema, example: exampleProduct } }
+    },
+    404: { description: 'Product missing', content: { 'application/json': { schema: errorSchema } } }
+  }
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/api/v1/products/{id}',
+  description: 'Update product',
+  request: {
+    params: z.object({ id: z.string() }),
+    body: { content: { 'application/json': { schema: productCreateSchema.partial(), example: { stockQty: 150 } } } }
+  },
+  responses: {
+    200: {
+      description: 'Updated product',
+      content: { 'application/json': { schema: productSchema, example: exampleProduct } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/api/v1/products/{id}',
+  description: 'Delete product',
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    204: { description: 'Deleted' }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/v1/invoices',
+  description: 'Create invoice with items',
+  request: {
+    body: { content: { 'application/json': { schema: invoiceCreateSchema, example: exampleInvoiceCreate } } }
+  },
+  responses: {
+    201: {
+      description: 'Created invoice',
+      content: { 'application/json': { schema: invoiceSchema, example: exampleInvoice } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/invoices/{id}',
+  description: 'Get invoice by id',
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: {
+      description: 'Invoice',
+      content: { 'application/json': { schema: invoiceSchema, example: exampleInvoice } }
+    },
+    404: { description: 'Invoice missing', content: { 'application/json': { schema: errorSchema } } }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/invoices',
+  description: 'Search invoices',
+  request: { query: invoiceListQuerySchema },
+  responses: {
+    200: {
+      description: 'Invoices',
+      content: {
+        'application/json': {
+          schema: invoiceListResponseSchema,
+          example: { data: [exampleInvoice], pagination: { total: 1, limit: 20, offset: 0 } }
+        }
+      }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/v1/payments',
+  description: 'Record a payment',
+  request: {
+    body: { content: { 'application/json': { schema: paymentCreateSchema, example: examplePaymentCreate } } }
+  },
+  responses: {
+    201: {
+      description: 'Payment recorded',
+      content: { 'application/json': { schema: paymentSchema, example: examplePayment } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/payments',
+  description: 'List payments',
+  request: { query: paymentListQuerySchema },
+  responses: {
+    200: {
+      description: 'Payments',
+      content: {
+        'application/json': {
+          schema: paymentListResponseSchema,
+          example: { data: [examplePayment], pagination: { total: 1, limit: 20, offset: 0 } }
+        }
+      }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/payments/{id}',
+  description: 'Payment details',
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: {
+      description: 'Payment',
+      content: { 'application/json': { schema: paymentSchema, example: examplePayment } }
+    },
+    404: { description: 'Payment missing', content: { 'application/json': { schema: errorSchema } } }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/reports/dues',
+  description: 'Outstanding balances per customer',
+  responses: {
+    200: {
+      description: 'Dues report',
+      content: { 'application/json': { schema: duesReportSchema, example: exampleDuesReport } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/reports/sales',
+  description: 'Sales totals over time',
+  request: { query: salesReportQuerySchema },
+  responses: {
+    200: {
+      description: 'Sales report',
+      content: { 'application/json': { schema: salesReportSchema, example: exampleSalesReport } }
+    }
+  }
+});
+
+const generator = new OpenApiGeneratorV31(registry.definitions);
+
+export const createOpenApiDocument = () =>
+  generator.generateDocument({
+    openapi: '3.1.0',
+    info: {
+      title: 'Stationery API',
+      version: '1.0.0',
+      description: 'Stationery shop management API built with Express and SQLite'
+    }
+  });

--- a/apps/api/src/errors.ts
+++ b/apps/api/src/errors.ts
@@ -1,0 +1,14 @@
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    public code: string,
+    message: string,
+    public details?: unknown
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+export const createNotFoundError = (message: string) =>
+  new ApiError(404, 'not_found', message);

--- a/apps/api/src/middleware/error.ts
+++ b/apps/api/src/middleware/error.ts
@@ -1,0 +1,38 @@
+import type { NextFunction, Request, Response } from 'express';
+import { ZodError } from 'zod';
+import { ApiError } from '../errors.js';
+
+export function notFoundHandler(req: Request, _res: Response, next: NextFunction) {
+  next(new ApiError(404, 'not_found', `Route ${req.method} ${req.originalUrl} was not found`));
+}
+
+export function errorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+) {
+  if (err instanceof ZodError) {
+    res.status(400).json({
+      code: 'validation_error',
+      message: 'Request validation failed',
+      details: err.flatten()
+    });
+    return;
+  }
+
+  if (err instanceof ApiError) {
+    res.status(err.status).json({
+      code: err.code,
+      message: err.message,
+      ...(err.details ? { details: err.details } : {})
+    });
+    return;
+  }
+
+  console.error(err);
+  res.status(500).json({
+    code: 'internal_error',
+    message: 'An unexpected error occurred'
+  });
+}

--- a/apps/api/src/routes/customers.ts
+++ b/apps/api/src/routes/customers.ts
@@ -1,0 +1,198 @@
+import { Router } from 'express';
+import { desc, eq, like, or, sql } from 'drizzle-orm';
+import {
+  customerCreateSchema,
+  customerLedgerSchema,
+  customerListQuerySchema,
+  customerListResponseSchema,
+  customerSchema,
+  customerUpdateSchema
+} from '@stationery/shared';
+import { ApiError, createNotFoundError } from '../errors.js';
+import { customerLedgerView, customers, db } from '../db/client.js';
+import { asyncHandler } from '../utils/async-handler.js';
+import { toIsoDateTime } from '../utils/datetime.js';
+
+const router = Router();
+
+const toSearchTerm = (value: string) => `%${value}%`;
+
+router.get(
+  '/',
+  asyncHandler((req, res) => {
+    const query = customerListQuerySchema.parse(req.query);
+    const term = query.query ? toSearchTerm(query.query) : undefined;
+
+    const whereClause = term
+      ? or(
+          like(customers.name, term),
+          like(customers.email, term),
+          like(customers.phone, term)
+        )
+      : undefined;
+
+    const orderColumn = query.sort === 'name' ? customers.name : customers.createdAt;
+
+    let selection = db.select().from(customers);
+    if (whereClause) {
+      selection = selection.where(whereClause);
+    }
+
+    selection =
+      query.direction === 'asc'
+        ? selection.orderBy(orderColumn)
+        : selection.orderBy(desc(orderColumn));
+
+    const rows = selection.limit(query.limit).offset(query.offset).all();
+
+    let countQuery = db.select({ count: sql<number>`count(*)` }).from(customers);
+    if (whereClause) {
+      countQuery = countQuery.where(whereClause);
+    }
+
+    const total = countQuery.get()?.count ?? rows.length;
+
+    const payload = customerListResponseSchema.parse({
+      data: rows.map(row => ({
+        ...row,
+        createdAt: toIsoDateTime(row.createdAt)
+      })),
+      pagination: {
+        total,
+        limit: query.limit,
+        offset: query.offset
+      }
+    });
+
+    res.json(payload);
+  })
+);
+
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    const body = customerCreateSchema.parse(req.body);
+
+    const inserted = db
+      .insert(customers)
+      .values(body)
+      .returning({ id: customers.id })
+      .get();
+
+    if (!inserted?.id) {
+      throw new ApiError(500, 'insert_failed', 'Failed to create customer');
+    }
+
+    const created = await db.query.customers.findFirst({
+      where: eq(customers.id, inserted.id)
+    });
+
+    if (!created) {
+      throw new ApiError(500, 'fetch_failed', 'Failed to load created customer');
+    }
+
+    const payload = customerSchema.parse({
+      ...created,
+      createdAt: toIsoDateTime(created.createdAt)
+    });
+
+    res.status(201).json(payload);
+  })
+);
+
+router.get(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const id = Number.parseInt(req.params.id, 10);
+    const parsedId = customerSchema.shape.id.parse(id);
+
+    const row = await db.query.customers.findFirst({
+      where: eq(customers.id, parsedId)
+    });
+
+    if (!row) {
+      throw createNotFoundError(`Customer ${parsedId} not found`);
+    }
+
+    const payload = customerSchema.parse({
+      ...row,
+      createdAt: toIsoDateTime(row.createdAt)
+    });
+
+    res.json(payload);
+  })
+);
+
+router.put(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const id = Number.parseInt(req.params.id, 10);
+    const parsedId = customerSchema.shape.id.parse(id);
+    const body = customerUpdateSchema.parse(req.body);
+
+    const updated = db
+      .update(customers)
+      .set(body)
+      .where(eq(customers.id, parsedId))
+      .returning()
+      .get();
+
+    if (!updated) {
+      throw createNotFoundError(`Customer ${parsedId} not found`);
+    }
+
+    const fresh = await db.query.customers.findFirst({
+      where: eq(customers.id, parsedId)
+    });
+
+    if (!fresh) {
+      throw createNotFoundError(`Customer ${parsedId} not found`);
+    }
+
+    const payload = customerSchema.parse({
+      ...fresh,
+      createdAt: toIsoDateTime(fresh.createdAt)
+    });
+
+    res.json(payload);
+  })
+);
+
+router.delete(
+  '/:id',
+  asyncHandler((req, res) => {
+    const id = Number.parseInt(req.params.id, 10);
+    const parsedId = customerSchema.shape.id.parse(id);
+
+    const result = db.delete(customers).where(eq(customers.id, parsedId)).run();
+
+    if (result.changes === 0) {
+      throw createNotFoundError(`Customer ${parsedId} not found`);
+    }
+
+    res.status(204).send();
+  })
+);
+
+router.get(
+  '/:id/ledger',
+  asyncHandler(async (req, res) => {
+    const id = Number.parseInt(req.params.id, 10);
+    const parsedId = customerSchema.shape.id.parse(id);
+
+    const row = db
+      .select()
+      .from(customerLedgerView)
+      .where(eq(customerLedgerView.customerId, parsedId))
+      .get();
+
+    if (!row) {
+      throw createNotFoundError(`Ledger for customer ${parsedId} not found`);
+    }
+
+    const payload = customerLedgerSchema.parse(row);
+    res.json(payload);
+  })
+);
+
+export { router as customersRouter };

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import { customersRouter } from './customers.js';
+import { healthRouter } from './health.js';
+import { invoicesRouter } from './invoices.js';
+import { paymentsRouter } from './payments.js';
+import { productsRouter } from './products.js';
+import { reportsRouter } from './reports.js';
+
+const apiRouter = Router();
+
+apiRouter.use('/health', healthRouter);
+apiRouter.use('/customers', customersRouter);
+apiRouter.use('/products', productsRouter);
+apiRouter.use('/invoices', invoicesRouter);
+apiRouter.use('/payments', paymentsRouter);
+apiRouter.use('/reports', reportsRouter);
+
+export { apiRouter };

--- a/apps/api/src/routes/invoices.ts
+++ b/apps/api/src/routes/invoices.ts
@@ -1,0 +1,258 @@
+import { Router } from 'express';
+import type { SQL } from 'drizzle-orm';
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+import {
+  invoiceCreateSchema,
+  invoiceListQuerySchema,
+  invoiceListResponseSchema,
+  invoiceSchema,
+  invoiceStatusSchema
+} from '@stationery/shared';
+import { ApiError, createNotFoundError } from '../errors.js';
+import {
+  customers,
+  db,
+  invoiceItems,
+  invoices,
+  payments,
+  products
+} from '../db/client.js';
+import { asyncHandler } from '../utils/async-handler.js';
+import { toIsoDateTime } from '../utils/datetime.js';
+import type {
+  InferSelectModel
+} from 'drizzle-orm';
+
+const router = Router();
+
+const normalizeIso = (value: string | null | undefined) => toIsoDateTime(value);
+
+type InvoiceRow = InferSelectModel<typeof invoices> & {
+  customer?: InferSelectModel<typeof customers> | null;
+  items: InferSelectModel<typeof invoiceItems>[];
+  payments: InferSelectModel<typeof payments>[];
+};
+
+const normalizeInvoice = (invoice: InvoiceRow) =>
+  invoiceSchema.parse({
+    ...invoice,
+    issueDate: normalizeIso(invoice.issueDate),
+    notes: invoice.notes ?? null,
+    customer: invoice.customer
+      ? {
+          ...invoice.customer,
+          createdAt: normalizeIso(invoice.customer.createdAt)
+        }
+      : undefined,
+    items: (invoice.items ?? []).map(item => ({
+      ...item,
+      description: item.description ?? null
+    })),
+    payments: (invoice.payments ?? []).map(payment => ({
+      ...payment,
+      note: payment.note ?? undefined,
+      paidAt: normalizeIso(payment.paidAt)
+    }))
+  });
+
+const buildInvoiceNumber = () => {
+  const now = new Date();
+  const prefix = `INV-${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}`;
+  const likePattern = `${prefix}%`;
+  const countResult = db
+    .select({ count: sql<number>`count(*)` })
+    .from(invoices)
+    .where(sql`invoice_no LIKE ${likePattern}`)
+    .get();
+  const nextSequence = (countResult?.count ?? 0) + 1;
+  return `${prefix}-${String(nextSequence).padStart(4, '0')}`;
+};
+
+const fetchInvoiceById = (id: number) =>
+  db.query.invoices.findFirst({
+    where: eq(invoices.id, id),
+    with: {
+      customer: true,
+      items: true,
+      payments: true
+    }
+  });
+
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    const payload = invoiceCreateSchema.parse(req.body);
+
+    const customer = await db.query.customers.findFirst({
+      where: eq(customers.id, payload.customerId)
+    });
+
+    if (!customer) {
+      throw new ApiError(400, 'invalid_customer', 'Customer does not exist');
+    }
+
+    const productIds = Array.from(new Set(payload.items.map(item => item.productId)));
+    const dbProducts = productIds.length
+      ? db.select().from(products).where(inArray(products.id, productIds)).all()
+      : [];
+
+    if (dbProducts.length !== productIds.length) {
+      throw new ApiError(400, 'invalid_product', 'One or more products do not exist');
+    }
+
+    const itemsWithTotals = payload.items.map(item => ({
+      ...item,
+      lineTotalCents: item.quantity * item.unitPriceCents
+    }));
+
+    const subTotalCents = itemsWithTotals.reduce((sum, item) => sum + item.lineTotalCents, 0);
+    const discountCents = payload.discountCents ?? 0;
+    const taxCents = payload.taxCents ?? 0;
+    const grandTotalCents = Math.max(subTotalCents - discountCents + taxCents, 0);
+
+    const invoiceNo = payload.invoiceNo ?? buildInvoiceNumber();
+    const issueDate = payload.issueDate ?? new Date().toISOString();
+
+    const insertedId = db.transaction(tx => {
+      const insertedInvoice = tx
+        .insert(invoices)
+        .values({
+          invoiceNo,
+          customerId: payload.customerId,
+          issueDate,
+          subTotalCents,
+          discountCents,
+          taxCents,
+          grandTotalCents,
+          status: payload.status ?? invoiceStatusSchema.enum.draft,
+          notes: payload.notes ?? null
+        })
+        .returning({ id: invoices.id })
+        .get();
+
+      if (!insertedInvoice) {
+        throw new ApiError(500, 'insert_failed', 'Failed to create invoice');
+      }
+
+      tx.insert(invoiceItems)
+        .values(
+          itemsWithTotals.map(item => ({
+            invoiceId: insertedInvoice.id,
+            productId: item.productId,
+            description: item.description,
+            quantity: item.quantity,
+            unitPriceCents: item.unitPriceCents,
+            lineTotalCents: item.lineTotalCents
+          }))
+        )
+        .run();
+
+      return insertedInvoice.id;
+    });
+
+    const record = await fetchInvoiceById(insertedId);
+
+    if (!record) {
+      throw new ApiError(500, 'fetch_failed', 'Created invoice could not be retrieved');
+    }
+
+    const payloadResponse = normalizeInvoice(record as InvoiceRow);
+
+    res.status(201).json(payloadResponse);
+  })
+);
+
+router.get(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const id = Number.parseInt(req.params.id, 10);
+    const parsedId = invoiceSchema.shape.id.parse(id);
+
+    const record = await fetchInvoiceById(parsedId);
+
+    if (!record) {
+      throw createNotFoundError(`Invoice ${parsedId} not found`);
+    }
+
+    const payloadResponse = normalizeInvoice(record as InvoiceRow);
+    res.json(payloadResponse);
+  })
+);
+
+router.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const query = invoiceListQuerySchema.parse(req.query);
+    const statuses = query.status
+      ? Array.isArray(query.status)
+        ? query.status
+        : [query.status]
+      : undefined;
+
+    const filters: SQL[] = [];
+
+    if (statuses?.length) {
+      filters.push(inArray(invoices.status, statuses));
+    }
+
+    if (query.customerId) {
+      filters.push(eq(invoices.customerId, query.customerId));
+    }
+
+    if (query.from) {
+      filters.push(sql`datetime(${invoices.issueDate}) >= datetime(${query.from} || ' 00:00:00')`);
+    }
+
+    if (query.to) {
+      filters.push(sql`datetime(${invoices.issueDate}) <= datetime(${query.to} || ' 23:59:59')`);
+    }
+
+    if (query.query) {
+      const term = `%${query.query}%`;
+      filters.push(sql`${invoices.invoiceNo} LIKE ${term}`);
+    }
+
+    const whereClause: SQL | undefined =
+      filters.length === 0
+        ? undefined
+        : filters.length === 1
+          ? (filters[0] as SQL)
+          : and(...(filters as [SQL, SQL, ...SQL[]]));
+
+    const rows = await db.query.invoices.findMany({
+      where: whereClause,
+      with: {
+        customer: true,
+        items: true,
+        payments: true
+      },
+      limit: query.limit,
+      offset: query.offset,
+      orderBy: fields => [
+        query.direction === 'asc'
+          ? fields[query.sort === 'invoiceNo' ? 'invoiceNo' : 'issueDate']
+          : desc(fields[query.sort === 'invoiceNo' ? 'invoiceNo' : 'issueDate'])
+      ]
+    });
+
+    let countQuery = db.select({ count: sql<number>`count(*)` }).from(invoices);
+    if (whereClause) {
+      countQuery = countQuery.where(whereClause);
+    }
+
+    const total = countQuery.get()?.count ?? rows.length;
+
+    const payload = invoiceListResponseSchema.parse({
+      data: rows.map(record => normalizeInvoice(record as InvoiceRow)),
+      pagination: {
+        total,
+        limit: query.limit,
+        offset: query.offset
+      }
+    });
+
+    res.json(payload);
+  })
+);
+
+export { router as invoicesRouter };

--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -1,0 +1,152 @@
+import { Router } from 'express';
+import type { SQL } from 'drizzle-orm';
+import { and, desc, eq, sql } from 'drizzle-orm';
+import {
+  paymentCreateSchema,
+  paymentListQuerySchema,
+  paymentListResponseSchema,
+  paymentSchema
+} from '@stationery/shared';
+import { ApiError, createNotFoundError } from '../errors.js';
+import { customers, db, invoices, payments } from '../db/client.js';
+import { asyncHandler } from '../utils/async-handler.js';
+import { toIsoDateTime } from '../utils/datetime.js';
+
+const router = Router();
+
+const normalizePayment = (payment: typeof payments.$inferSelect) =>
+  paymentSchema.parse({
+    ...payment,
+    note: payment.note ?? undefined,
+    paidAt: toIsoDateTime(payment.paidAt)
+  });
+
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    const payload = paymentCreateSchema.parse(req.body);
+
+    const customer = await db.query.customers.findFirst({
+      where: eq(customers.id, payload.customerId)
+    });
+
+    if (!customer) {
+      throw new ApiError(400, 'invalid_customer', 'Customer does not exist');
+    }
+
+    if (payload.invoiceId) {
+      const invoice = await db.query.invoices.findFirst({
+        where: eq(invoices.id, payload.invoiceId)
+      });
+
+      if (!invoice) {
+        throw new ApiError(400, 'invalid_invoice', 'Invoice does not exist');
+      }
+
+      if (invoice.customerId !== payload.customerId) {
+        throw new ApiError(400, 'invoice_customer_mismatch', 'Invoice does not belong to the customer');
+      }
+    }
+
+    const paidAt = payload.paidAt ?? new Date().toISOString();
+
+    const inserted = db
+      .insert(payments)
+      .values({
+        ...payload,
+        paidAt,
+        note: payload.note ?? null
+      })
+      .returning()
+      .get();
+
+    if (!inserted) {
+      throw new ApiError(500, 'insert_failed', 'Failed to record payment');
+    }
+
+    const responsePayload = normalizePayment(inserted);
+    res.status(201).json(responsePayload);
+  })
+);
+
+router.get(
+  '/',
+  asyncHandler((req, res) => {
+    const query = paymentListQuerySchema.parse(req.query);
+
+    const filters: SQL[] = [];
+
+    if (query.customerId) {
+      filters.push(eq(payments.customerId, query.customerId));
+    }
+
+    if (query.invoiceId) {
+      filters.push(eq(payments.invoiceId, query.invoiceId));
+    }
+
+    if (query.from) {
+      filters.push(sql`datetime(${payments.paidAt}) >= datetime(${query.from} || ' 00:00:00')`);
+    }
+
+    if (query.to) {
+      filters.push(sql`datetime(${payments.paidAt}) <= datetime(${query.to} || ' 23:59:59')`);
+    }
+
+    const whereClause: SQL | undefined =
+      filters.length === 0
+        ? undefined
+        : filters.length === 1
+          ? filters[0]
+          : and(...(filters as [SQL, SQL, ...SQL[]]));
+
+    let selection = db.select().from(payments);
+    if (whereClause) {
+      selection = selection.where(whereClause);
+    }
+
+    selection =
+      query.direction === 'asc'
+        ? selection.orderBy(payments.paidAt)
+        : selection.orderBy(desc(payments.paidAt));
+
+    const rows = selection.limit(query.limit).offset(query.offset).all();
+
+    let countQuery = db.select({ count: sql<number>`count(*)` }).from(payments);
+    if (whereClause) {
+      countQuery = countQuery.where(whereClause);
+    }
+
+    const total = countQuery.get()?.count ?? rows.length;
+
+    const payload = paymentListResponseSchema.parse({
+      data: rows.map(normalizePayment),
+      pagination: {
+        total,
+        limit: query.limit,
+        offset: query.offset
+      }
+    });
+
+    res.json(payload);
+  })
+);
+
+router.get(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const id = Number.parseInt(req.params.id, 10);
+    const parsedId = paymentSchema.shape.id.parse(id);
+
+    const record = await db.query.payments.findFirst({
+      where: eq(payments.id, parsedId)
+    });
+
+    if (!record) {
+      throw createNotFoundError(`Payment ${parsedId} not found`);
+    }
+
+    res.json(normalizePayment(record));
+  })
+);
+
+export { router as paymentsRouter };

--- a/apps/api/src/routes/products.ts
+++ b/apps/api/src/routes/products.ts
@@ -1,0 +1,173 @@
+import { Router } from 'express';
+import { desc, eq, like, or, sql } from 'drizzle-orm';
+import {
+  productCreateSchema,
+  productListQuerySchema,
+  productListResponseSchema,
+  productSchema,
+  productUpdateSchema
+} from '@stationery/shared';
+import { ApiError, createNotFoundError } from '../errors.js';
+import { db, products } from '../db/client.js';
+import { asyncHandler } from '../utils/async-handler.js';
+import { toIsoDateTime } from '../utils/datetime.js';
+
+const router = Router();
+
+const toSearchTerm = (value: string) => `%${value}%`;
+
+router.get(
+  '/',
+  asyncHandler((req, res) => {
+    const query = productListQuerySchema.parse(req.query);
+    const term = query.query ? toSearchTerm(query.query) : undefined;
+
+    const whereClause = term
+      ? or(like(products.name, term), like(products.sku, term), like(products.description, term))
+      : undefined;
+
+    const orderColumn =
+      query.sort === 'name' ? products.name : query.sort === 'sku' ? products.sku : products.createdAt;
+
+    let selection = db.select().from(products);
+    if (whereClause) {
+      selection = selection.where(whereClause);
+    }
+
+    selection =
+      query.direction === 'asc'
+        ? selection.orderBy(orderColumn)
+        : selection.orderBy(desc(orderColumn));
+
+    const rows = selection.limit(query.limit).offset(query.offset).all();
+
+    let countQuery = db.select({ count: sql<number>`count(*)` }).from(products);
+    if (whereClause) {
+      countQuery = countQuery.where(whereClause);
+    }
+
+    const total = countQuery.get()?.count ?? rows.length;
+
+    const payload = productListResponseSchema.parse({
+      data: rows.map(row => ({
+        ...row,
+        createdAt: toIsoDateTime(row.createdAt)
+      })),
+      pagination: {
+        total,
+        limit: query.limit,
+        offset: query.offset
+      }
+    });
+
+    res.json(payload);
+  })
+);
+
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    const body = productCreateSchema.parse(req.body);
+
+    const inserted = db
+      .insert(products)
+      .values(body)
+      .returning({ id: products.id })
+      .get();
+
+    if (!inserted?.id) {
+      throw new ApiError(500, 'insert_failed', 'Failed to create product');
+    }
+
+    const created = await db.query.products.findFirst({
+      where: eq(products.id, inserted.id)
+    });
+
+    if (!created) {
+      throw new ApiError(500, 'fetch_failed', 'Failed to load created product');
+    }
+
+    const payload = productSchema.parse({
+      ...created,
+      createdAt: toIsoDateTime(created.createdAt)
+    });
+
+    res.status(201).json(payload);
+  })
+);
+
+router.get(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const id = Number.parseInt(req.params.id, 10);
+    const parsedId = productSchema.shape.id.parse(id);
+
+    const row = await db.query.products.findFirst({
+      where: eq(products.id, parsedId)
+    });
+
+    if (!row) {
+      throw createNotFoundError(`Product ${parsedId} not found`);
+    }
+
+    const payload = productSchema.parse({
+      ...row,
+      createdAt: toIsoDateTime(row.createdAt)
+    });
+
+    res.json(payload);
+  })
+);
+
+router.put(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const id = Number.parseInt(req.params.id, 10);
+    const parsedId = productSchema.shape.id.parse(id);
+    const body = productUpdateSchema.parse(req.body);
+
+    const updated = db
+      .update(products)
+      .set(body)
+      .where(eq(products.id, parsedId))
+      .returning()
+      .get();
+
+    if (!updated) {
+      throw createNotFoundError(`Product ${parsedId} not found`);
+    }
+
+    const fresh = await db.query.products.findFirst({
+      where: eq(products.id, parsedId)
+    });
+
+    if (!fresh) {
+      throw createNotFoundError(`Product ${parsedId} not found`);
+    }
+
+    const payload = productSchema.parse({
+      ...fresh,
+      createdAt: toIsoDateTime(fresh.createdAt)
+    });
+
+    res.json(payload);
+  })
+);
+
+router.delete(
+  '/:id',
+  asyncHandler((req, res) => {
+    const id = Number.parseInt(req.params.id, 10);
+    const parsedId = productSchema.shape.id.parse(id);
+
+    const result = db.delete(products).where(eq(products.id, parsedId)).run();
+
+    if (result.changes === 0) {
+      throw createNotFoundError(`Product ${parsedId} not found`);
+    }
+
+    res.status(204).send();
+  })
+);
+
+export { router as productsRouter };

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,0 +1,83 @@
+import { Router } from 'express';
+import type { SQL } from 'drizzle-orm';
+import { and, inArray, sql } from 'drizzle-orm';
+import {
+  customerLedgerSchema,
+  duesReportSchema,
+  salesReportQuerySchema,
+  salesReportSchema
+} from '@stationery/shared';
+import { db, customerLedgerView, invoices } from '../db/client.js';
+import { asyncHandler } from '../utils/async-handler.js';
+
+const router = Router();
+
+router.get(
+  '/dues',
+  asyncHandler((_req, res) => {
+    const ledgerRows = db.select().from(customerLedgerView).all();
+    const payload = duesReportSchema.parse({
+      generatedAt: new Date().toISOString(),
+      customers: ledgerRows.map(row => customerLedgerSchema.parse(row))
+    });
+
+    res.json(payload);
+  })
+);
+
+const groupFormats = {
+  day: '%Y-%m-%d',
+  week: '%Y-%W',
+  month: '%Y-%m'
+} as const;
+
+router.get(
+  '/sales',
+  asyncHandler((req, res) => {
+    const query = salesReportQuerySchema.parse(req.query);
+
+    const filters: SQL[] = [inArray(invoices.status, ['issued', 'partial', 'paid'])];
+
+    if (query.from) {
+      filters.push(sql`datetime(${invoices.issueDate}) >= datetime(${query.from} || ' 00:00:00')`);
+    }
+
+    if (query.to) {
+      filters.push(sql`datetime(${invoices.issueDate}) <= datetime(${query.to} || ' 23:59:59')`);
+    }
+
+    const whereClause: SQL | undefined =
+      filters.length === 0
+        ? undefined
+        : filters.length === 1
+          ? filters[0]
+          : and(...(filters as [SQL, SQL, ...SQL[]]));
+
+    const strftimeFormat = groupFormats[query.groupBy];
+
+    const rows = db
+      .select({
+        period: sql<string>`strftime(${strftimeFormat}, ${invoices.issueDate})`,
+        invoicesCount: sql<number>`count(*)`,
+        totalCents: sql<number>`sum(${invoices.grandTotalCents})`
+      })
+      .from(invoices)
+      .where(whereClause)
+      .groupBy(sql`strftime(${strftimeFormat}, ${invoices.issueDate})`)
+      .orderBy(sql`strftime(${strftimeFormat}, ${invoices.issueDate})`)
+      .all();
+
+    const payload = salesReportSchema.parse({
+      generatedAt: new Date().toISOString(),
+      rows: rows.map(row => ({
+        period: row.period,
+        invoicesCount: row.invoicesCount ?? 0,
+        totalCents: row.totalCents ?? 0
+      }))
+    });
+
+    res.json(payload);
+  })
+);
+
+export { router as reportsRouter };

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -1,12 +1,123 @@
+import { readFileSync } from 'node:fs';
+import { describe, beforeAll, beforeEach, expect, it } from 'vitest';
 import request from 'supertest';
-import { describe, expect, it } from 'vitest';
-import { createServer } from './server.js';
+import {
+  exampleCustomerCreate,
+  exampleInvoiceCreate,
+  examplePaymentCreate,
+  exampleProductCreate
+} from '@stationery/shared';
+
+let app: import('express').Express;
+let sqlite: import('better-sqlite3');
+let dbModule: Awaited<ReturnType<typeof importDbModule>>;
+
+async function importDbModule() {
+  process.env.DATABASE_URL = ':memory:';
+  return import('./db/client.js');
+}
+
+beforeAll(async () => {
+  dbModule = await importDbModule();
+  const migrationPath = new URL('../drizzle/0000_slippery_onslaught.sql', import.meta.url);
+  const migrationSql = readFileSync(migrationPath, 'utf8');
+  dbModule.sqlite.exec(migrationSql);
+  const { createServer } = await import('./server.js');
+  app = createServer();
+  sqlite = dbModule.sqlite;
+});
+
+beforeEach(() => {
+  sqlite.exec(
+    [
+      'DELETE FROM invoice_items;',
+      'DELETE FROM payments;',
+      'DELETE FROM invoices;',
+      'DELETE FROM products;',
+      'DELETE FROM customers;'
+    ].join('\n')
+  );
+});
 
 describe('API server', () => {
-  it('responds to /health', async () => {
-    const app = createServer();
-    const response = await request(app).get('/health');
+  it('responds to /api/v1/health', async () => {
+    const response = await request(app).get('/api/v1/health');
     expect(response.status).toBe(200);
     expect(response.body.status).toBe('ok');
+    expect(response.body.checks[0].status).toBe('pass');
+  });
+
+  it('creates and retrieves customers using documented payloads', async () => {
+    const createResponse = await request(app).post('/api/v1/customers').send(exampleCustomerCreate);
+    expect(createResponse.status).toBe(201);
+    const customerId = createResponse.body.id;
+
+    const getResponse = await request(app).get(`/api/v1/customers/${customerId}`);
+    expect(getResponse.status).toBe(200);
+    expect(getResponse.body.name).toBe(exampleCustomerCreate.name);
+
+    const listResponse = await request(app).get('/api/v1/customers');
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.data).toHaveLength(1);
+  });
+
+  it('handles invoices, payments, and reports end-to-end', async () => {
+    const customer = dbModule.db
+      .insert(dbModule.customers)
+      .values(exampleCustomerCreate)
+      .returning()
+      .get();
+
+    const product = dbModule.db
+      .insert(dbModule.products)
+      .values(exampleProductCreate)
+      .returning()
+      .get();
+
+    const invoicePayload = {
+      ...exampleInvoiceCreate,
+      customerId: customer.id,
+      items: [
+        {
+          productId: product.id,
+          quantity: 2,
+          unitPriceCents: product.unitPriceCents,
+          description: product.description
+        }
+      ]
+    };
+
+    const invoiceResponse = await request(app).post('/api/v1/invoices').send(invoicePayload);
+    expect(invoiceResponse.status).toBe(201);
+    const invoiceId = invoiceResponse.body.id;
+    expect(invoiceResponse.body.items).toHaveLength(1);
+
+    const paymentPayload = {
+      ...examplePaymentCreate,
+      customerId: customer.id,
+      invoiceId,
+      amountCents: invoiceResponse.body.grandTotalCents / 2
+    };
+
+    const paymentResponse = await request(app).post('/api/v1/payments').send(paymentPayload);
+    expect(paymentResponse.status).toBe(201);
+
+    const listInvoices = await request(app).get('/api/v1/invoices');
+    expect(listInvoices.status).toBe(200);
+    expect(listInvoices.body.data[0].id).toBe(invoiceId);
+
+    const duesReport = await request(app).get('/api/v1/reports/dues');
+    expect(duesReport.status).toBe(200);
+    expect(duesReport.body.customers[0].balanceCents).toBe(
+      invoiceResponse.body.grandTotalCents - paymentPayload.amountCents
+    );
+
+    const salesReport = await request(app).get('/api/v1/reports/sales');
+    expect(salesReport.status).toBe(200);
+    expect(salesReport.body.rows.length).toBeGreaterThan(0);
+
+    const docsResponse = await request(app).get('/docs/openapi.json');
+    expect(docsResponse.status).toBe(200);
+    expect(docsResponse.body.paths['/api/v1/invoices']).toBeDefined();
   });
 });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,15 +1,28 @@
 import express from 'express';
-import { healthRouter } from './routes/health.js';
+import swaggerUi from 'swagger-ui-express';
+import { apiRouter } from './routes/index.js';
+import { errorHandler, notFoundHandler } from './middleware/error.js';
+import { createOpenApiDocument } from './docs/openapi.js';
 
 export function createServer() {
   const app = express();
 
   app.use(express.json());
-  app.use('/health', healthRouter);
+  const openApiDocument = createOpenApiDocument();
+
+  app.get('/docs/openapi.json', (_req, res) => {
+    res.json(openApiDocument);
+  });
+  app.use('/docs', swaggerUi.serve, swaggerUi.setup(openApiDocument));
 
   app.get('/', (_req, res) => {
-    res.json({ message: 'Stationery API' });
+    res.json({ message: 'Stationery API', docs: '/docs' });
   });
+
+  app.use('/api/v1', apiRouter);
+
+  app.use(notFoundHandler);
+  app.use(errorHandler);
 
   return app;
 }

--- a/apps/api/src/utils/async-handler.ts
+++ b/apps/api/src/utils/async-handler.ts
@@ -1,0 +1,9 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+
+export const asyncHandler = <TRequest extends Request = Request, TResponse extends Response = Response>(
+  handler: (req: TRequest, res: TResponse, next: NextFunction) => Promise<unknown> | unknown
+): RequestHandler => {
+  return (req, res, next) => {
+    Promise.resolve(handler(req as TRequest, res as TResponse, next)).catch(next);
+  };
+};

--- a/apps/api/src/utils/datetime.ts
+++ b/apps/api/src/utils/datetime.ts
@@ -1,0 +1,16 @@
+export const toIsoDateTime = (value: string | null | undefined): string => {
+  if (!value) {
+    return new Date().toISOString();
+  }
+
+  const hasTimeSeparator = value.includes('T') ? value : value.replace(' ', 'T');
+  const hasZone = /[zZ]|[+-]\d{2}:?\d{2}?$/.test(hasTimeSeparator);
+  const candidate = hasZone ? hasTimeSeparator : `${hasTimeSeparator}Z`;
+  const parsed = new Date(candidate);
+
+  if (Number.isNaN(parsed.valueOf())) {
+    return new Date().toISOString();
+  }
+
+  return parsed.toISOString();
+};

--- a/apps/web/src/root-app.test.ts
+++ b/apps/web/src/root-app.test.ts
@@ -1,10 +1,11 @@
 import { fixture, html } from '@open-wc/testing';
 import { describe, expect, it } from 'vitest';
+import { exampleCustomer } from '@stationery/shared';
 import './root-app';
 
 describe('app-root', () => {
   it('renders shared greeting', async () => {
     const element = await fixture<HTMLElement>(html`<app-root></app-root>`);
-    expect(element.shadowRoot?.textContent).toContain('Hello, from the shared package!');
+    expect(element.shadowRoot?.textContent).toContain(`Hello, ${exampleCustomer.name}!`);
   });
 });

--- a/apps/web/src/root-app.ts
+++ b/apps/web/src/root-app.ts
@@ -1,6 +1,6 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { createGreeting } from '@stationery/shared';
+import { exampleCustomer } from '@stationery/shared';
 
 @customElement('app-root')
 export class AppRoot extends LitElement {
@@ -37,7 +37,7 @@ export class AppRoot extends LitElement {
   `;
 
   @state()
-  private message = createGreeting('from the shared package');
+  private message = `Hello, ${exampleCustomer.name}!`;
 
   protected render() {
     return html`

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,6 +10,9 @@
     "lint": "eslint . --ext .ts",
     "format": "prettier --write \"src/**/*.ts\""
   },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
   "devDependencies": {
     "typescript": "^5.4.5",
     "vitest": "^1.5.2"

--- a/packages/shared/src/common.ts
+++ b/packages/shared/src/common.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+export const idSchema = z.number().int().positive();
+
+export const dateTimeStringSchema = z
+  .string()
+  .min(1)
+  .refine(value => !Number.isNaN(Date.parse(value)), {
+    message: 'Invalid date-time value'
+  });
+
+export const dateOnlyStringSchema = z
+  .string()
+  .trim()
+  .regex(/^\d{4}-\d{2}-\d{2}$/u, 'Date must be in YYYY-MM-DD format');
+
+export const moneyCentsSchema = z.number().int().min(0);
+
+export const paginationSchema = z.object({
+  total: z.number().int().min(0),
+  limit: z.number().int().min(1),
+  offset: z.number().int().min(0)
+});
+
+export const listQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+  query: z.string().trim().min(1).max(120).optional()
+});
+
+export type Pagination = z.infer<typeof paginationSchema>;

--- a/packages/shared/src/customers.ts
+++ b/packages/shared/src/customers.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+import {
+  dateTimeStringSchema,
+  idSchema,
+  listQuerySchema,
+  moneyCentsSchema,
+  paginationSchema
+} from './common.js';
+
+const phoneRegex = /^[+0-9()\-\s]{7,20}$/;
+
+export const customerSchema = z.object({
+  id: idSchema,
+  name: z.string().trim().min(1).max(120),
+  phone: z
+    .string()
+    .trim()
+    .regex(phoneRegex, 'Phone numbers may contain digits, spaces, dashes, parentheses or a leading +')
+    .optional(),
+  email: z.string().trim().email().optional(),
+  address: z.string().trim().max(240).optional(),
+  createdAt: dateTimeStringSchema
+});
+
+export const customerCreateSchema = customerSchema
+  .omit({ id: true, createdAt: true })
+  .strict();
+
+export const customerUpdateSchema = customerCreateSchema.partial().refine(
+  data => Object.keys(data).length > 0,
+  'At least one field must be provided to update a customer'
+);
+
+export const customerListQuerySchema = listQuerySchema.extend({
+  sort: z.enum(['createdAt', 'name']).default('createdAt'),
+  direction: z.enum(['asc', 'desc']).default('desc')
+});
+
+export const customerListResponseSchema = z.object({
+  data: z.array(customerSchema),
+  pagination: paginationSchema
+});
+
+export const customerLedgerSchema = z.object({
+  customerId: idSchema,
+  customerName: z.string().min(1),
+  invoicedCents: moneyCentsSchema,
+  paidCents: moneyCentsSchema,
+  balanceCents: z.number().int()
+});
+
+export type Customer = z.infer<typeof customerSchema>;
+export type CustomerCreateInput = z.infer<typeof customerCreateSchema>;
+export type CustomerUpdateInput = z.infer<typeof customerUpdateSchema>;
+export type CustomerListQuery = z.infer<typeof customerListQuerySchema>;
+export type CustomerListResponse = z.infer<typeof customerListResponseSchema>;
+export type CustomerLedger = z.infer<typeof customerLedgerSchema>;
+
+export const exampleCustomerCreate: CustomerCreateInput = {
+  name: 'Acme Studios',
+  email: 'team@acme.test',
+  phone: '+1 555 123 4567',
+  address: '42 Paper Street'
+};
+
+export const exampleCustomer: Customer = {
+  id: 1,
+  ...exampleCustomerCreate,
+  createdAt: '2024-01-01T00:00:00.000Z'
+};
+
+export const exampleCustomerLedger: CustomerLedger = {
+  customerId: 1,
+  customerName: exampleCustomerCreate.name,
+  invoicedCents: 12500,
+  paidCents: 7500,
+  balanceCents: 5000
+};

--- a/packages/shared/src/health.ts
+++ b/packages/shared/src/health.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import { dateTimeStringSchema } from './common.js';
+
+export const healthCheckSchema = z.object({
+  status: z.literal('ok'),
+  version: z.string().min(1),
+  timestamp: dateTimeStringSchema,
+  uptimeSeconds: z.number().min(0),
+  checks: z.array(
+    z.object({
+      name: z.string().min(1),
+      status: z.enum(['pass', 'fail']),
+      message: z.string().optional()
+    })
+  )
+});
+
+export type HealthCheck = z.infer<typeof healthCheckSchema>;
+
+export const healthCheckExample: HealthCheck = {
+  status: 'ok',
+  version: '1.0.0',
+  timestamp: '2024-01-01T00:00:00.000Z',
+  uptimeSeconds: 1,
+  checks: [
+    {
+      name: 'database',
+      status: 'pass'
+    }
+  ]
+};

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -1,9 +1,64 @@
 import { describe, expect, it } from 'vitest';
 
-import { createGreeting } from './index.js';
+import {
+  customerCreateSchema,
+  customerUpdateSchema,
+  duesReportSchema,
+  exampleCustomerCreate,
+  exampleDuesReport,
+  exampleInvoice,
+  exampleInvoiceCreate,
+  examplePayment,
+  examplePaymentCreate,
+  exampleProduct,
+  exampleProductCreate,
+  exampleSalesReport,
+  healthCheckExample,
+  healthCheckSchema,
+  invoiceCreateSchema,
+  invoiceSchema,
+  paymentCreateSchema,
+  paymentSchema,
+  productCreateSchema,
+  productSchema,
+  salesReportQuerySchema,
+  salesReportSchema
+} from './index.js';
 
-describe('createGreeting', () => {
-  it('returns a personalized greeting', () => {
-    expect(createGreeting('Stationery')).toBe('Hello, Stationery!');
+describe('shared schemas', () => {
+  it('accepts the documented customer example', () => {
+    expect(() => customerCreateSchema.parse(exampleCustomerCreate)).not.toThrow();
+  });
+
+  it('rejects empty customer updates', () => {
+    expect(() => customerUpdateSchema.parse({})).toThrowError(
+      /At least one field must be provided to update a customer/
+    );
+  });
+
+  it('accepts the documented product example', () => {
+    expect(() => productCreateSchema.parse(exampleProductCreate)).not.toThrow();
+    expect(() => productSchema.parse(exampleProduct)).not.toThrow();
+  });
+
+  it('validates invoice payloads and relations', () => {
+    expect(() => invoiceCreateSchema.parse(exampleInvoiceCreate)).not.toThrow();
+    expect(() => invoiceSchema.parse(exampleInvoice)).not.toThrow();
+  });
+
+  it('validates payment payloads', () => {
+    expect(() => paymentCreateSchema.parse(examplePaymentCreate)).not.toThrow();
+    expect(() => paymentSchema.parse(examplePayment)).not.toThrow();
+  });
+
+  it('validates health and report documents used in docs', () => {
+    expect(() => healthCheckSchema.parse(healthCheckExample)).not.toThrow();
+    expect(() => duesReportSchema.parse(exampleDuesReport)).not.toThrow();
+    expect(() => salesReportSchema.parse(exampleSalesReport)).not.toThrow();
+  });
+
+  it('applies default grouping in sales report query', () => {
+    const result = salesReportQuerySchema.parse({});
+    expect(result.groupBy).toBe('month');
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,7 @@
-export function createGreeting(name: string): string {
-  return `Hello, ${name}!`;
-}
+export * from './common.js';
+export * from './customers.js';
+export * from './products.js';
+export * from './invoices.js';
+export * from './payments.js';
+export * from './reports.js';
+export * from './health.js';

--- a/packages/shared/src/invoices.ts
+++ b/packages/shared/src/invoices.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod';
+import {
+  dateOnlyStringSchema,
+  dateTimeStringSchema,
+  idSchema,
+  listQuerySchema,
+  moneyCentsSchema,
+  paginationSchema
+} from './common.js';
+import { customerSchema, exampleCustomer } from './customers.js';
+import { examplePayment, paymentSchema } from './payments.js';
+import { exampleProduct } from './products.js';
+
+export const invoiceStatusSchema = z.enum(['draft', 'issued', 'partial', 'paid', 'void']);
+
+export const invoiceItemInputSchema = z.object({
+  productId: idSchema,
+  description: z.string().trim().max(240).optional(),
+  quantity: z.number().int().min(1),
+  unitPriceCents: moneyCentsSchema
+});
+
+export const invoiceItemSchema = invoiceItemInputSchema.extend({
+  id: idSchema,
+  invoiceId: idSchema,
+  lineTotalCents: moneyCentsSchema,
+  description: z.string().trim().max(240).nullable().optional()
+});
+
+export const invoiceBaseSchema = z.object({
+  id: idSchema,
+  invoiceNo: z.string().trim().min(1).max(64),
+  customerId: idSchema,
+  issueDate: dateTimeStringSchema,
+  subTotalCents: moneyCentsSchema,
+  discountCents: moneyCentsSchema,
+  taxCents: moneyCentsSchema,
+  grandTotalCents: moneyCentsSchema,
+  status: invoiceStatusSchema,
+  notes: z.string().trim().max(500).nullable().optional()
+});
+
+export const invoiceSchema = invoiceBaseSchema.extend({
+  customer: customerSchema.optional(),
+  items: z.array(invoiceItemSchema),
+  payments: z.array(paymentSchema)
+});
+
+export const invoiceCreateSchema = z
+  .object({
+    invoiceNo: z.string().trim().min(1).max(64).optional(),
+    customerId: idSchema,
+    issueDate: dateTimeStringSchema.optional(),
+    status: invoiceStatusSchema.default('draft'),
+    discountCents: moneyCentsSchema.default(0),
+    taxCents: moneyCentsSchema.default(0),
+    notes: z.string().trim().max(500).optional(),
+    items: z.array(invoiceItemInputSchema).min(1)
+  })
+  .strict();
+
+export const invoiceListQuerySchema = listQuerySchema.extend({
+  status: z.array(invoiceStatusSchema).or(invoiceStatusSchema).optional(),
+  customerId: z.coerce.number().int().positive().optional(),
+  from: dateOnlyStringSchema.optional(),
+  to: dateOnlyStringSchema.optional(),
+  sort: z.enum(['issueDate', 'invoiceNo']).default('issueDate'),
+  direction: z.enum(['asc', 'desc']).default('desc')
+});
+
+export const invoiceListResponseSchema = z.object({
+  data: z.array(invoiceSchema),
+  pagination: paginationSchema
+});
+
+export type InvoiceItemInput = z.infer<typeof invoiceItemInputSchema>;
+export type InvoiceItem = z.infer<typeof invoiceItemSchema>;
+export type Invoice = z.infer<typeof invoiceSchema>;
+export type InvoiceCreateInput = z.infer<typeof invoiceCreateSchema>;
+export type InvoiceListQuery = z.infer<typeof invoiceListQuerySchema>;
+export type InvoiceListResponse = z.infer<typeof invoiceListResponseSchema>;
+
+export const exampleInvoiceCreate: InvoiceCreateInput = {
+  customerId: exampleCustomer.id,
+  invoiceNo: 'INV-2024-0001',
+  status: 'issued',
+  discountCents: 0,
+  taxCents: 500,
+  notes: 'Thank you for your business!',
+  items: [
+    {
+      productId: exampleProduct.id,
+      quantity: 2,
+      unitPriceCents: exampleProduct.unitPriceCents,
+      description: exampleProduct.description
+    }
+  ]
+};
+
+export const exampleInvoice: Invoice = {
+  id: 1,
+  customerId: exampleCustomer.id,
+  invoiceNo: exampleInvoiceCreate.invoiceNo!,
+  issueDate: '2024-01-05T00:00:00.000Z',
+  subTotalCents: exampleProduct.unitPriceCents * 2,
+  discountCents: exampleInvoiceCreate.discountCents,
+  taxCents: exampleInvoiceCreate.taxCents,
+  grandTotalCents:
+    exampleProduct.unitPriceCents * 2 - exampleInvoiceCreate.discountCents + exampleInvoiceCreate.taxCents,
+  status: exampleInvoiceCreate.status,
+  notes: exampleInvoiceCreate.notes,
+  customer: exampleCustomer,
+  items: [
+    {
+      id: 1,
+      invoiceId: 1,
+      productId: exampleProduct.id,
+      quantity: 2,
+      unitPriceCents: exampleProduct.unitPriceCents,
+      lineTotalCents: exampleProduct.unitPriceCents * 2,
+      description: exampleProduct.description
+    }
+  ],
+  payments: [examplePayment]
+};

--- a/packages/shared/src/payments.ts
+++ b/packages/shared/src/payments.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import {
+  dateOnlyStringSchema,
+  dateTimeStringSchema,
+  idSchema,
+  listQuerySchema,
+  moneyCentsSchema,
+  paginationSchema
+} from './common.js';
+
+export const paymentMethodSchema = z.enum(['cash', 'bkash', 'card', 'other']);
+
+export const paymentSchema = z.object({
+  id: idSchema,
+  customerId: idSchema,
+  invoiceId: idSchema.nullish(),
+  amountCents: moneyCentsSchema.min(1),
+  method: paymentMethodSchema,
+  paidAt: dateTimeStringSchema,
+  note: z.string().trim().max(240).optional()
+});
+
+export const paymentCreateSchema = paymentSchema
+  .omit({ id: true, paidAt: true })
+  .extend({
+    paidAt: dateTimeStringSchema.optional()
+  })
+  .strict();
+
+export const paymentListQuerySchema = listQuerySchema.extend({
+  customerId: z.coerce.number().int().positive().optional(),
+  invoiceId: z.coerce.number().int().positive().optional(),
+  from: dateOnlyStringSchema.optional(),
+  to: dateOnlyStringSchema.optional(),
+  sort: z.enum(['paidAt']).default('paidAt'),
+  direction: z.enum(['asc', 'desc']).default('desc')
+});
+
+export const paymentListResponseSchema = z.object({
+  data: z.array(paymentSchema),
+  pagination: paginationSchema
+});
+
+export type Payment = z.infer<typeof paymentSchema>;
+export type PaymentCreateInput = z.infer<typeof paymentCreateSchema>;
+export type PaymentListQuery = z.infer<typeof paymentListQuerySchema>;
+export type PaymentListResponse = z.infer<typeof paymentListResponseSchema>;
+
+export const examplePaymentCreate: PaymentCreateInput = {
+  customerId: 1,
+  invoiceId: 1,
+  amountCents: 5000,
+  method: 'cash',
+  note: 'Deposit payment'
+};
+
+export const examplePayment: Payment = {
+  id: 1,
+  ...examplePaymentCreate,
+  paidAt: '2024-01-02T00:00:00.000Z'
+};

--- a/packages/shared/src/products.ts
+++ b/packages/shared/src/products.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+import {
+  dateTimeStringSchema,
+  idSchema,
+  listQuerySchema,
+  moneyCentsSchema,
+  paginationSchema
+} from './common.js';
+
+export const productSchema = z.object({
+  id: idSchema,
+  sku: z.string().trim().min(1).max(64),
+  name: z.string().trim().min(1).max(160),
+  description: z.string().trim().max(500).optional(),
+  unitPriceCents: moneyCentsSchema,
+  stockQty: z.number().int().min(0),
+  createdAt: dateTimeStringSchema
+});
+
+export const productCreateSchema = productSchema
+  .omit({ id: true, createdAt: true })
+  .strict();
+
+export const productUpdateSchema = productCreateSchema.partial().refine(
+  data => Object.keys(data).length > 0,
+  'At least one field must be provided to update a product'
+);
+
+export const productListQuerySchema = listQuerySchema.extend({
+  sort: z.enum(['createdAt', 'name', 'sku']).default('createdAt'),
+  direction: z.enum(['asc', 'desc']).default('desc')
+});
+
+export const productListResponseSchema = z.object({
+  data: z.array(productSchema),
+  pagination: paginationSchema
+});
+
+export type Product = z.infer<typeof productSchema>;
+export type ProductCreateInput = z.infer<typeof productCreateSchema>;
+export type ProductUpdateInput = z.infer<typeof productUpdateSchema>;
+export type ProductListQuery = z.infer<typeof productListQuerySchema>;
+export type ProductListResponse = z.infer<typeof productListResponseSchema>;
+
+export const exampleProductCreate: ProductCreateInput = {
+  sku: 'PAPER-A4-80',
+  name: 'A4 Copy Paper 80gsm',
+  description: 'Standard office copy paper.',
+  unitPriceCents: 549,
+  stockQty: 120
+};
+
+export const exampleProduct: Product = {
+  id: 1,
+  ...exampleProductCreate,
+  createdAt: '2024-01-01T00:00:00.000Z'
+};

--- a/packages/shared/src/reports.ts
+++ b/packages/shared/src/reports.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import { dateOnlyStringSchema, moneyCentsSchema } from './common.js';
+import { customerLedgerSchema, exampleCustomerLedger } from './customers.js';
+
+export const duesReportSchema = z.object({
+  customers: z.array(customerLedgerSchema),
+  generatedAt: z.string()
+});
+
+export type DuesReport = z.infer<typeof duesReportSchema>;
+
+export const exampleDuesReport: DuesReport = {
+  generatedAt: '2024-01-07T00:00:00.000Z',
+  customers: [exampleCustomerLedger]
+};
+
+export const salesReportQuerySchema = z.object({
+  from: dateOnlyStringSchema.optional(),
+  to: dateOnlyStringSchema.optional(),
+  groupBy: z.enum(['day', 'week', 'month']).default('month')
+});
+
+export const salesReportRowSchema = z.object({
+  period: z.string(),
+  invoicesCount: z.number().int().min(0),
+  totalCents: moneyCentsSchema
+});
+
+export const salesReportSchema = z.object({
+  rows: z.array(salesReportRowSchema),
+  generatedAt: z.string()
+});
+
+export type SalesReportQuery = z.infer<typeof salesReportQuerySchema>;
+export type SalesReportRow = z.infer<typeof salesReportRowSchema>;
+export type SalesReport = z.infer<typeof salesReportSchema>;
+
+export const exampleSalesReport: SalesReport = {
+  generatedAt: '2024-01-07T00:00:00.000Z',
+  rows: [
+    {
+      period: '2024-01',
+      invoicesCount: 3,
+      totalCents: 42000
+    }
+  ]
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@asteasolutions/zod-to-openapi':
+        specifier: 7.1.0
+        version: 7.1.0(zod@3.23.8)
       '@stationery/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -68,6 +71,9 @@ importers:
       express:
         specifier: 4.19.2
         version: 4.19.2
+      swagger-ui-express:
+        specifier: 5.0.1
+        version: 5.0.1(express@4.19.2)
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -141,6 +147,10 @@ importers:
         version: 1.5.2(@types/node@20.12.7)(jsdom@24.1.3)(terser@5.44.0)
 
   packages/shared:
+    dependencies:
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       typescript:
         specifier: ^5.4.5
@@ -156,6 +166,11 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@asteasolutions/zod-to-openapi@7.1.0':
+    resolution: {integrity: sha512-7E0k56zXV01GaSSWIuVVcHonBBPDtM6DKJqcHTNz4cfRjy1nQTAEslYjEvJd83PZ7gvhXs8NJ5aR1y/L76zt/Q==}
+    peerDependencies:
+      zod: ^3.20.2
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -1315,6 +1330,9 @@ packages:
     resolution: {integrity: sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==}
     cpu: [x64]
     os: [win32]
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -3166,6 +3184,9 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
+  openapi3-ts@4.5.0:
+    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -3661,6 +3682,15 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swagger-ui-dist@5.29.3:
+    resolution: {integrity: sha512-U99f/2YocRA2Mxqx3eUBRhQonWVtE5dIvMs0Zlsn4a4ip8awMq0JxXhU+Sidtna2WlZrHbK2Rro3RZvYUymRbA==}
+
+  swagger-ui-express@5.0.1:
+    resolution: {integrity: sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==}
+    engines: {node: '>= v0.10.32'}
+    peerDependencies:
+      express: '>=4.0.0 || >=5.0.0-beta'
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -4006,6 +4036,11 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@2.8.1:
+    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -4040,6 +4075,11 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@asteasolutions/zod-to-openapi@7.1.0(zod@3.23.8)':
+    dependencies:
+      openapi3-ts: 4.5.0
+      zod: 3.23.8
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -5128,6 +5168,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.52.4':
     optional: true
+
+  '@scarf/scarf@1.4.0': {}
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -7345,6 +7387,10 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  openapi3-ts@4.5.0:
+    dependencies:
+      yaml: 2.8.1
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -7903,6 +7949,15 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swagger-ui-dist@5.29.3:
+    dependencies:
+      '@scarf/scarf': 1.4.0
+
+  swagger-ui-express@5.0.1(express@4.19.2):
+    dependencies:
+      express: 4.19.2
+      swagger-ui-dist: 5.29.3
+
   symbol-tree@3.2.4: {}
 
   synckit@0.8.8:
@@ -8248,6 +8303,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.8.1: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Summary
- add v1 API routers with centralized error handling and utilities
- define shared zod schemas/examples and use them for OpenAPI 3.1 generation and Swagger docs
- update server/tests to validate new endpoints and documentation responses

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68e542bce200832eab3a1fa4ebc6d632