### PR TITLE
feat(web): add app shell and core billing pages

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,10 @@
   },
   "dependencies": {
     "lit": "3.1.2",
-    "@stationery/shared": "workspace:*"
+    "@stationery/shared": "workspace:*",
+    "@lit-labs/router": "0.1.4",
+    "chart.js": "4.4.3",
+    "motion": "12.23.22"
   },
   "devDependencies": {
     "@playwright/test": "^1.43.1",

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,0 +1,222 @@
+import {
+  customerCreateSchema,
+  customerListQuerySchema,
+  customerListResponseSchema,
+  customerSchema,
+  duesReportSchema,
+  invoiceCreateSchema,
+  invoiceListQuerySchema,
+  invoiceListResponseSchema,
+  invoiceSchema,
+  paymentCreateSchema,
+  paymentListQuerySchema,
+  paymentListResponseSchema,
+  paymentSchema,
+  productCreateSchema,
+  productListQuerySchema,
+  productListResponseSchema,
+  productSchema,
+  salesReportQuerySchema,
+  salesReportSchema,
+  type Customer,
+  type CustomerCreateInput,
+  type CustomerListQuery,
+  type CustomerListResponse,
+  type Invoice,
+  type InvoiceCreateInput,
+  type InvoiceListQuery,
+  type InvoiceListResponse,
+  type Payment,
+  type PaymentCreateInput,
+  type PaymentListQuery,
+  type PaymentListResponse,
+  type Product,
+  type ProductCreateInput,
+  type ProductListQuery,
+  type ProductListResponse,
+  type DuesReport,
+  type SalesReport,
+  type SalesReportQuery
+} from '@stationery/shared';
+import { z } from 'zod';
+
+const API_BASE = '/api/v1';
+
+const jsonHeaders = { 'Content-Type': 'application/json' } as const;
+
+export class ApiClientError extends Error {
+  status: number;
+  details?: unknown;
+
+  constructor(message: string, status: number, details?: unknown) {
+    super(message);
+    this.name = 'ApiClientError';
+    this.status = status;
+    this.details = details;
+  }
+}
+
+type Query = Record<string, string | number | boolean | undefined | null>;
+
+const buildUrl = (path: string, query?: Query) => {
+  const url = new URL(`${API_BASE}${path}`, window.location.origin);
+  if (query) {
+    Object.entries(query).forEach(([key, value]) => {
+      if (value === undefined || value === null || value === '') return;
+      url.searchParams.set(key, String(value));
+    });
+  }
+  return url;
+};
+
+const parseResponse = async <T>(response: Response, schema: z.ZodType<T> | null) => {
+  if (response.status === 204) {
+    return null as T;
+  }
+
+  const text = await response.text();
+  if (!text) {
+    return null as T;
+  }
+
+  const data = JSON.parse(text);
+  if (!schema) {
+    return data as T;
+  }
+  return schema.parse(data);
+};
+
+const request = async <T>(path: string, options: RequestInit & { query?: Query; schema?: z.ZodType<T> | null }) => {
+  const { query, schema = null, ...init } = options;
+  const url = buildUrl(path, query);
+  const response = await fetch(url, init);
+
+  if (!response.ok) {
+    let details: unknown;
+    try {
+      details = await response.json();
+    } catch (error) {
+      details = undefined;
+    }
+    throw new ApiClientError(response.statusText || 'Request failed', response.status, details);
+  }
+
+  return parseResponse(response, schema);
+};
+
+export const fetchCustomers = async (query: CustomerListQuery = {}) =>
+  request<CustomerListResponse>('/customers', {
+    method: 'GET',
+    query: customerListQuerySchema.parse(query),
+    schema: customerListResponseSchema
+  });
+
+export const createCustomer = async (input: CustomerCreateInput) =>
+  request<Customer>('/customers', {
+    method: 'POST',
+    headers: jsonHeaders,
+    body: JSON.stringify(customerCreateSchema.parse(input)),
+    schema: customerSchema
+  });
+
+export const fetchCustomer = async (id: number) =>
+  request<Customer>(`/customers/${id}`, {
+    method: 'GET',
+    schema: customerSchema
+  });
+
+export const fetchProducts = async (query: ProductListQuery = {}) =>
+  request<ProductListResponse>('/products', {
+    method: 'GET',
+    query: productListQuerySchema.parse(query),
+    schema: productListResponseSchema
+  });
+
+export const createProduct = async (input: ProductCreateInput) =>
+  request<Product>('/products', {
+    method: 'POST',
+    headers: jsonHeaders,
+    body: JSON.stringify(productCreateSchema.parse(input)),
+    schema: productSchema
+  });
+
+export const createInvoice = async (input: InvoiceCreateInput) =>
+  request<Invoice>('/invoices', {
+    method: 'POST',
+    headers: jsonHeaders,
+    body: JSON.stringify(invoiceCreateSchema.parse(input)),
+    schema: invoiceSchema
+  });
+
+export const fetchInvoice = async (id: number) =>
+  request<Invoice>(`/invoices/${id}`, {
+    method: 'GET',
+    schema: invoiceSchema
+  });
+
+export const fetchInvoices = async (query: InvoiceListQuery = {}) =>
+  request<InvoiceListResponse>('/invoices', {
+    method: 'GET',
+    query: invoiceListQuerySchema.parse(query),
+    schema: invoiceListResponseSchema
+  });
+
+export const createPayment = async (input: PaymentCreateInput) =>
+  request<Payment>('/payments', {
+    method: 'POST',
+    headers: jsonHeaders,
+    body: JSON.stringify(paymentCreateSchema.parse(input)),
+    schema: paymentSchema
+  });
+
+export const fetchPayments = async (query: PaymentListQuery = {}) =>
+  request<PaymentListResponse>('/payments', {
+    method: 'GET',
+    query: paymentListQuerySchema.parse(query),
+    schema: paymentListResponseSchema
+  });
+
+export const fetchDuesReport = async () =>
+  request<DuesReport>('/reports/dues', {
+    method: 'GET',
+    schema: duesReportSchema
+  });
+
+export const fetchSalesReport = async (query: SalesReportQuery) =>
+  request<SalesReport>('/reports/sales', {
+    method: 'GET',
+    query: salesReportQuerySchema.parse(query),
+    schema: salesReportSchema
+  });
+
+export const requestInvoicePdf = async (invoiceId: number, payload?: Record<string, unknown>) => {
+  const response = await fetch(buildUrl(`/invoices/${invoiceId}/pdf`), {
+    method: 'POST',
+    headers: jsonHeaders,
+    body: JSON.stringify(payload ?? {})
+  });
+
+  if (!response.ok) {
+    throw new ApiClientError(response.statusText || 'Failed to load PDF', response.status);
+  }
+
+  return response.blob();
+};
+
+export type {
+  Customer,
+  CustomerCreateInput,
+  CustomerListResponse,
+  Product,
+  ProductCreateInput,
+  ProductListResponse,
+  Invoice,
+  InvoiceCreateInput,
+  InvoiceListResponse,
+  Payment,
+  PaymentCreateInput,
+  PaymentListResponse,
+  DuesReport,
+  SalesReport,
+  SalesReportQuery
+};

--- a/apps/web/src/app-shell.ts
+++ b/apps/web/src/app-shell.ts
@@ -1,0 +1,371 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { animate } from 'motion';
+import { AppRouter, isRouteActive, navigationRoutes, type NavigationRoute } from './router.js';
+
+const prefersReducedMotion =
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-reduced-motion: reduce)')
+    : ({ matches: false } as MediaQueryList);
+
+@customElement('app-shell')
+export class AppShell extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+      min-height: 100vh;
+      background: var(--color-bg);
+      color: var(--color-text);
+    }
+
+    .layout {
+      display: grid;
+      grid-template-columns: 260px 1fr;
+      min-height: 100vh;
+      background: var(--color-bg);
+    }
+
+    nav {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-sm);
+      padding: var(--space-xl) var(--space-lg);
+      background: linear-gradient(180deg, var(--color-surface), var(--color-surface-strong));
+      border-right: 1px solid var(--color-border);
+    }
+
+    nav h1 {
+      font-size: 1.25rem;
+      margin: 0 0 var(--space-lg);
+      font-weight: 700;
+      letter-spacing: -0.01em;
+    }
+
+    nav ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: var(--space-xs);
+    }
+
+    nav button {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      align-items: center;
+      gap: var(--space-sm);
+      width: 100%;
+      border: 1px solid transparent;
+      border-radius: var(--radius-md);
+      padding: var(--space-sm) var(--space-md);
+      background: transparent;
+      text-align: left;
+      font-size: 0.95rem;
+      color: var(--color-text-subtle);
+      transition: transform var(--transition-snappy), border-color var(--transition-snappy),
+        background var(--transition-snappy), color var(--transition-snappy);
+    }
+
+    nav button span.icon {
+      font-size: 1.15rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    nav button span.copy {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2xs);
+    }
+
+    nav button span.copy strong {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: inherit;
+    }
+
+    nav button span.copy small {
+      font-size: 0.8rem;
+      color: var(--color-text-muted);
+    }
+
+    nav button.active {
+      background: rgba(37, 99, 235, 0.12);
+      border-color: rgba(37, 99, 235, 0.35);
+      color: var(--color-primary);
+      box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.15);
+    }
+
+    nav button:hover:not(.active),
+    nav button:focus-visible:not(.active) {
+      border-color: rgba(37, 99, 235, 0.2);
+      background: rgba(37, 99, 235, 0.08);
+      color: var(--color-primary-strong);
+    }
+
+    main {
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: var(--space-lg) var(--space-2xl) var(--space-md);
+      position: sticky;
+      top: 0;
+      background: rgba(245, 247, 251, 0.85);
+      backdrop-filter: blur(18px);
+      z-index: 10;
+      border-bottom: 1px solid rgba(215, 222, 234, 0.6);
+    }
+
+    header h2 {
+      margin: 0;
+      font-size: 1.5rem;
+      letter-spacing: -0.01em;
+      color: var(--color-text);
+    }
+
+    header p {
+      margin: var(--space-2xs) 0 0;
+      color: var(--color-text-muted);
+      font-size: 0.95rem;
+    }
+
+    .header-meta {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .header-meta > div {
+      display: flex;
+      align-items: center;
+      gap: var(--space-sm);
+    }
+
+    .header-actions {
+      display: flex;
+      gap: var(--space-sm);
+    }
+
+    .header-actions button {
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--color-border);
+      background: var(--color-surface);
+      padding: var(--space-sm) var(--space-lg);
+      font-size: 0.9rem;
+      color: var(--color-text);
+      box-shadow: var(--shadow-sm);
+    }
+
+    .header-actions button.primary {
+      background: var(--color-primary);
+      color: white;
+      border-color: var(--color-primary-strong);
+      box-shadow: 0 12px 30px rgba(37, 99, 235, 0.18);
+    }
+
+    .content {
+      flex: 1;
+      padding: 0 var(--space-2xl) var(--space-2xl);
+      display: block;
+    }
+
+    .menu-toggle {
+      display: none;
+    }
+
+    .content-inner {
+      background: var(--color-surface);
+      border-radius: var(--radius-lg);
+      padding: var(--space-2xl);
+      box-shadow: var(--shadow-md);
+      min-height: calc(100vh - 200px);
+    }
+
+    @media (max-width: 960px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+
+      nav {
+        position: fixed;
+        inset: 0 auto 0 0;
+        width: min(80vw, 320px);
+        transform: translateX(-100%);
+        transition: transform var(--transition-snappy);
+        box-shadow: var(--shadow-lg);
+        z-index: 20;
+      }
+
+      nav.open {
+        transform: translateX(0);
+      }
+
+      .backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 23, 42, 0.35);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity var(--transition-snappy);
+        z-index: 15;
+      }
+
+      .backdrop.visible {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      header {
+        padding: var(--space-md) var(--space-xl);
+      }
+
+      .content {
+        padding: 0 var(--space-lg) var(--space-xl);
+      }
+
+      .content-inner {
+        padding: var(--space-xl);
+        min-height: unset;
+      }
+
+      .menu-toggle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--color-border);
+        background: var(--color-surface);
+        padding: var(--space-xs) var(--space-sm);
+        margin-right: var(--space-sm);
+      }
+    }
+  `;
+
+  private router = new AppRouter(this, (route, url) => {
+    this.currentPath = `${url.pathname}${url.search}${url.hash}`;
+    document.title = `Stationery · ${route.label}`;
+    const content = this.renderRoot?.querySelector('.content-inner');
+    if (content && !prefersReducedMotion.matches) {
+      animate(content, { opacity: [0, 1], y: [12, 0] }, { duration: 0.18, easing: 'ease-out' });
+    }
+  });
+
+  @state()
+  private currentPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+  @state()
+  private sidebarOpen = false;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    window.addEventListener('keydown', this.handleKeydown);
+  }
+
+  disconnectedCallback(): void {
+    window.removeEventListener('keydown', this.handleKeydown);
+    super.disconnectedCallback();
+  }
+
+  private get currentRoute(): NavigationRoute {
+    return navigationRoutes.find(route => isRouteActive(route, this.currentPath)) ?? navigationRoutes[0];
+  }
+
+  private handleNavClick(route: NavigationRoute) {
+    this.router.navigate(route.path);
+    this.sidebarOpen = false;
+    queueMicrotask(() => {
+      const main = this.renderRoot?.querySelector('main');
+      (main as HTMLElement | null)?.focus();
+    });
+  }
+
+  private toggleSidebar() {
+    this.sidebarOpen = !this.sidebarOpen;
+  }
+
+  private handleBackdropClick = () => {
+    this.sidebarOpen = false;
+  };
+
+  private handleKeydown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && this.sidebarOpen) {
+      this.sidebarOpen = false;
+    }
+  };
+
+  private handleNavigate = (event: CustomEvent<string>) => {
+    event.stopPropagation();
+    if (event.detail) {
+      this.router.navigate(event.detail);
+    }
+  };
+
+  protected render() {
+    const sidebarRoutes = navigationRoutes.filter(route => route.includeInSidebar);
+    const route = this.currentRoute;
+
+    return html`
+      <div class="layout">
+        <div class="backdrop ${this.sidebarOpen ? 'visible' : ''}" @click=${this.handleBackdropClick}></div>
+        <nav class=${this.sidebarOpen ? 'open' : ''}>
+          <h1>Stationery HQ</h1>
+          <ul role="list">
+            ${sidebarRoutes.map(nav => {
+              const active = isRouteActive(nav, this.currentPath);
+              return html`
+                <li>
+                  <button
+                    type="button"
+                    class=${active ? 'active' : ''}
+                    aria-current=${active ? 'page' : 'false'}
+                    @click=${() => this.handleNavClick(nav)}
+                  >
+                    <span class="icon" aria-hidden="true">${nav.icon}</span>
+                    <span class="copy">
+                      <strong>${nav.label}</strong>
+                      <small>${nav.description}</small>
+                    </span>
+                  </button>
+                </li>
+              `;
+            })}
+          </ul>
+        </nav>
+        <main tabindex="-1">
+          <header>
+            <div class="header-meta">
+              <div>
+                <button class="menu-toggle" @click=${this.toggleSidebar} aria-label="Toggle navigation">☰</button>
+                <h2>${route.label}</h2>
+              </div>
+              <p>${route.description}</p>
+            </div>
+            <div class="header-actions">
+              <button type="button" @click=${() => this.router.navigate('/invoices/new')}>New invoice</button>
+              <button type="button" class="primary" @click=${() => this.router.navigate('/customers')}>
+                Add customer
+              </button>
+            </div>
+          </header>
+          <section class="content">
+            <div class="content-inner" role="region" aria-live="polite" @navigate=${this.handleNavigate}>
+              ${this.router.render()}
+            </div>
+          </section>
+        </main>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'app-shell': AppShell;
+  }
+}

--- a/apps/web/src/components/customer-list.ts
+++ b/apps/web/src/components/customer-list.ts
@@ -1,0 +1,248 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import type { Customer } from '../api/client.js';
+import { formatDate, formatRelativeDate } from '../utils/format.js';
+
+@customElement('customer-list')
+export class CustomerList extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+      background: var(--color-surface);
+      border-radius: var(--radius-lg);
+      border: 1px solid var(--color-border);
+      box-shadow: var(--shadow-sm);
+      overflow: hidden;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--space-sm);
+      padding: var(--space-md) var(--space-lg);
+      border-bottom: 1px solid var(--color-border);
+      background: linear-gradient(180deg, rgba(37, 99, 235, 0.07), transparent);
+    }
+
+    header h3 {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--color-text);
+    }
+
+    header span {
+      font-size: 0.85rem;
+      color: var(--color-text-muted);
+    }
+
+    input[type='search'] {
+      width: 100%;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--color-border);
+      background: var(--color-surface);
+      padding: var(--space-sm) var(--space-md);
+      font-size: 0.9rem;
+    }
+
+    input[type='search']:focus-visible {
+      border-color: var(--color-primary);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+      outline: none;
+    }
+
+    ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      max-height: 420px;
+      overflow-y: auto;
+    }
+
+    li + li {
+      border-top: 1px solid rgba(215, 222, 234, 0.6);
+    }
+
+    button.customer {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: var(--space-sm);
+      width: 100%;
+      text-align: left;
+      border: none;
+      background: none;
+      padding: var(--space-md) var(--space-lg);
+      font-size: 0.9rem;
+      color: var(--color-text);
+    }
+
+    button.customer.is-active {
+      background: rgba(37, 99, 235, 0.12);
+      color: var(--color-primary);
+    }
+
+    .details {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .details strong {
+      font-size: 1rem;
+    }
+
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-xs) var(--space-sm);
+      color: var(--color-text-muted);
+      font-size: 0.75rem;
+    }
+
+    .empty {
+      padding: var(--space-lg);
+      text-align: center;
+      color: var(--color-text-muted);
+    }
+  `;
+
+  @property({ attribute: false })
+  customers: Customer[] = [];
+
+  @property({ type: Number })
+  selectedId?: number;
+
+  @property({ type: Boolean })
+  loading = false;
+
+  @state()
+  private query = '';
+
+  @state()
+  private activeIndex = 0;
+
+  get filteredCustomers() {
+    const term = this.query.trim().toLowerCase();
+    if (!term) return this.customers;
+    return this.customers.filter(customer =>
+      `${customer.name} ${customer.email ?? ''} ${customer.phone ?? ''}`.toLowerCase().includes(term)
+    );
+  }
+
+  private handleInput = (event: Event) => {
+    const target = event.target as HTMLInputElement;
+    this.query = target.value;
+    this.activeIndex = 0;
+  };
+
+  private selectCustomer(customer: Customer) {
+    this.selectedId = customer.id;
+    this.dispatchEvent(
+      new CustomEvent('customer-selected', {
+        detail: { customer },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  private handleListKeydown = (event: KeyboardEvent) => {
+    const customers = this.filteredCustomers;
+    if (!customers.length) return;
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      this.activeIndex = (this.activeIndex + 1) % customers.length;
+      this.selectedId = customers[this.activeIndex].id;
+      this.scrollIntoView(this.activeIndex);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      this.activeIndex = (this.activeIndex - 1 + customers.length) % customers.length;
+      this.selectedId = customers[this.activeIndex].id;
+      this.scrollIntoView(this.activeIndex);
+    } else if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      const customer = customers[this.activeIndex];
+      if (customer) {
+        this.selectCustomer(customer);
+      }
+    }
+  };
+
+  private scrollIntoView(index: number) {
+    const list = this.renderRoot.querySelector('ul');
+    const item = list?.children[index] as HTMLElement | undefined;
+    if (list && item) {
+      const itemTop = item.offsetTop;
+      const itemBottom = itemTop + item.offsetHeight;
+      if (itemTop < list.scrollTop) {
+        list.scrollTop = itemTop;
+      } else if (itemBottom > list.scrollTop + list.clientHeight) {
+        list.scrollTop = itemBottom - list.clientHeight;
+      }
+    }
+  }
+
+  protected updated(changed: Map<string, unknown>): void {
+    if (changed.has('customers') || changed.has('selectedId')) {
+      const index = this.filteredCustomers.findIndex(customer => customer.id === this.selectedId);
+      this.activeIndex = index >= 0 ? index : 0;
+    }
+  }
+
+  protected render() {
+    const customers = this.filteredCustomers;
+    return html`
+      <header>
+        <div>
+          <h3>Customers</h3>
+          <span>${this.loading ? 'Loading…' : `${customers.length} matches`}</span>
+        </div>
+        <input
+          type="search"
+          placeholder="Search name, email, phone"
+          aria-label="Search customers"
+          .value=${this.query}
+          @input=${this.handleInput}
+        />
+      </header>
+      ${customers.length
+        ? html`<ul role="listbox" tabindex="0" @keydown=${this.handleListKeydown}>
+            ${customers.map((customer, index) => {
+              const selected = this.selectedId === customer.id;
+              const active = index === this.activeIndex;
+              return html`
+                <li>
+                  <button
+                    type="button"
+                    class=${`customer ${selected || active ? 'is-active' : ''}`}
+                    role="option"
+                    aria-selected=${selected || active}
+                    @click=${() => this.selectCustomer(customer)}
+                  >
+                    <span class="details">
+                      <strong>${customer.name}</strong>
+                      <span class="meta">
+                        ${customer.email ? html`<span>${customer.email}</span>` : null}
+                        ${customer.phone ? html`<span>${customer.phone}</span>` : null}
+                        <span>Joined ${formatRelativeDate(customer.createdAt)}</span>
+                      </span>
+                    </span>
+                    <span class="meta">
+                      <span>${formatDate(customer.createdAt)}</span>
+                    </span>
+                  </button>
+                </li>
+              `;
+            })}
+          </ul>`
+        : html`<div class="empty" role="status">No customers found.</div>`}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'customer-list': CustomerList;
+  }
+}

--- a/apps/web/src/components/invoice-form.ts
+++ b/apps/web/src/components/invoice-form.ts
@@ -1,0 +1,427 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { calculateInvoiceTotals, invoiceStatusSchema, type InvoiceCreateInput } from '@stationery/shared';
+import type { Customer, Product } from '../api/client.js';
+import './product-picker.js';
+import './money-input.js';
+import { animate } from 'motion';
+import { formatCurrency } from '../utils/format.js';
+
+interface InvoiceLineDraft {
+  id: string;
+  productId?: number;
+  description?: string;
+  quantity: number;
+  unitPriceCents: number;
+}
+
+const newLine = (): InvoiceLineDraft => ({
+  id: Math.random().toString(36).slice(2),
+  quantity: 1,
+  unitPriceCents: 0
+});
+
+@customElement('invoice-form')
+export class InvoiceForm extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    form {
+      display: grid;
+      gap: var(--space-lg);
+    }
+
+    .lines {
+      display: grid;
+      gap: var(--space-md);
+    }
+
+    .line {
+      display: grid;
+      grid-template-columns: minmax(220px, 1.2fr) minmax(110px, 0.6fr) minmax(140px, 0.6fr) auto;
+      gap: var(--space-md);
+      align-items: end;
+      padding: var(--space-md);
+      border-radius: var(--radius-md);
+      border: 1px solid var(--color-border);
+      background: var(--color-surface);
+      box-shadow: var(--shadow-sm);
+    }
+
+    .line-main {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-sm);
+    }
+
+    .line-main input[type='text'] {
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--color-border);
+      padding: var(--space-sm) var(--space-md);
+      font-size: 0.9rem;
+    }
+
+    .line-main input[type='text']:focus-visible {
+      border-color: var(--color-primary);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+      outline: none;
+    }
+
+    .line-actions {
+      align-self: center;
+      display: flex;
+      gap: var(--space-xs);
+    }
+
+    .line-actions button {
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--color-border);
+      background: var(--color-surface);
+      padding: var(--space-xs) var(--space-sm);
+      font-size: 0.85rem;
+      color: var(--color-text-muted);
+    }
+
+    textarea {
+      width: 100%;
+      min-height: 80px;
+      padding: var(--space-md);
+      border-radius: var(--radius-md);
+      border: 1px solid var(--color-border);
+      resize: vertical;
+      font-family: inherit;
+      font-size: 0.95rem;
+    }
+
+    textarea:focus-visible {
+      border-color: var(--color-primary);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+      outline: none;
+    }
+
+    .summary {
+      display: grid;
+      gap: var(--space-sm);
+      border-radius: var(--radius-lg);
+      padding: var(--space-xl);
+      background: linear-gradient(160deg, rgba(37, 99, 235, 0.08), rgba(249, 115, 22, 0.08));
+      border: 1px solid rgba(37, 99, 235, 0.16);
+    }
+
+    .totals {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: var(--space-lg);
+      align-items: start;
+    }
+
+    .summary dl {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: var(--space-sm) var(--space-lg);
+      margin: 0;
+    }
+
+    .summary dt {
+      font-size: 0.85rem;
+      color: var(--color-text-muted);
+    }
+
+    .summary dd {
+      margin: 0;
+      font-weight: 600;
+    }
+
+    .footer {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: var(--space-md);
+      align-items: center;
+    }
+
+    select {
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--color-border);
+      padding: var(--space-sm) var(--space-md);
+      background: var(--color-surface);
+      font-size: 0.9rem;
+    }
+
+    .footer button[type='submit'] {
+      border-radius: var(--radius-md);
+      background: var(--color-primary);
+      color: white;
+      border: 1px solid var(--color-primary-strong);
+      padding: var(--space-md) var(--space-xl);
+      font-size: 1rem;
+      box-shadow: 0 12px 30px rgba(37, 99, 235, 0.2);
+    }
+
+    @media (max-width: 720px) {
+      .line {
+        grid-template-columns: 1fr;
+      }
+
+      .line-actions {
+        justify-content: flex-end;
+      }
+    }
+  `;
+
+  @property({ attribute: false })
+  products: Product[] = [];
+
+  @property({ attribute: false })
+  customer?: Customer;
+
+  @property({ type: Number })
+  discountCents = 0;
+
+  @property({ type: Number })
+  taxCents = 0;
+
+  @property({ type: String })
+  notes = '';
+
+  @property({ type: String })
+  status: InvoiceCreateInput['status'] = 'issued';
+
+  @property({ type: Boolean })
+  submitting = false;
+
+  @state()
+  private lines: InvoiceLineDraft[] = [newLine()];
+
+  private get totals() {
+    const validLines = this.lines.filter(line => line.productId && line.quantity > 0);
+    const calculation = calculateInvoiceTotals(
+      {
+        items: validLines.map(line => ({
+          productId: line.productId!,
+          quantity: line.quantity,
+          unitPriceCents: line.unitPriceCents,
+          description: line.description
+        })),
+        discountCents: this.discountCents,
+        taxCents: this.taxCents
+      },
+      { decimals: 0 }
+    );
+    return calculation;
+  }
+
+  private updateLine(id: string, changes: Partial<InvoiceLineDraft>) {
+    this.lines = this.lines.map(line => (line.id === id ? { ...line, ...changes } : line));
+  }
+
+  private removeLine(id: string) {
+    if (this.lines.length === 1) return;
+    this.lines = this.lines.filter(line => line.id !== id);
+  }
+
+  private handleProductSelect(id: string, product: Product) {
+    this.updateLine(id, {
+      productId: product.id,
+      unitPriceCents: product.unitPriceCents,
+      description: product.description ?? undefined
+    });
+  }
+
+  private handleQuantityInput(id: string, event: Event) {
+    const target = event.target as HTMLInputElement;
+    const value = Number.parseInt(target.value, 10);
+    this.updateLine(id, { quantity: Number.isNaN(value) ? 1 : Math.max(1, value) });
+  }
+
+  private handlePriceChange(id: string, value: number) {
+    this.updateLine(id, { unitPriceCents: value });
+  }
+
+  private handleDescriptionInput(id: string, event: Event) {
+    const target = event.target as HTMLInputElement;
+    this.updateLine(id, { description: target.value || undefined });
+  }
+
+  private handleNotesInput(event: Event) {
+    const target = event.target as HTMLTextAreaElement;
+    this.notes = target.value;
+  }
+
+  private handleStatusChange(event: Event) {
+    const target = event.target as HTMLSelectElement;
+    if (invoiceStatusSchema.safeParse(target.value).success) {
+      this.status = target.value as InvoiceCreateInput['status'];
+    }
+  }
+
+  private addLine() {
+    const line = newLine();
+    this.lines = [...this.lines, line];
+    this.updateComplete.then(() => {
+      const node = this.renderRoot.querySelector(`[data-line-id='${line.id}']`);
+      if (node) {
+        animate(node as Element, { opacity: [0, 1], y: [-6, 0] }, { duration: 0.18, easing: 'ease-out' });
+      }
+    });
+  }
+
+  private buildPayload(): InvoiceCreateInput | null {
+    if (!this.customer) return null;
+    const items = this.lines
+      .filter(line => line.productId && line.quantity > 0)
+      .map(line => ({
+        productId: line.productId!,
+        quantity: line.quantity,
+        unitPriceCents: line.unitPriceCents,
+        description: line.description
+      }));
+
+    if (!items.length) return null;
+
+    return {
+      customerId: this.customer.id,
+      status: this.status,
+      discountCents: this.discountCents,
+      taxCents: this.taxCents,
+      notes: this.notes || undefined,
+      items
+    };
+  }
+
+  private handleSubmit = (event: Event) => {
+    event.preventDefault();
+    const payload = this.buildPayload();
+    if (!payload) {
+      this.dispatchEvent(
+        new CustomEvent('invoice-invalid', { detail: { reason: 'missing_fields' }, bubbles: true, composed: true })
+      );
+      return;
+    }
+
+    this.dispatchEvent(
+      new CustomEvent<InvoiceCreateInput>('invoice-submit', {
+        detail: payload,
+        bubbles: true,
+        composed: true
+      })
+    );
+  };
+
+  protected render() {
+    const totals = this.totals;
+    return html`
+      <form @submit=${this.handleSubmit}>
+        <div class="lines">
+          ${this.lines.map(line => {
+            return html`
+              <div class="line" data-line-id=${line.id}>
+                <div class="line-main">
+                  <product-picker
+                    .products=${this.products}
+                    .value=${line.productId}
+                    @product-select=${(event: CustomEvent<{ product: Product }>) =>
+                      this.handleProductSelect(line.id, event.detail.product)}
+                  ></product-picker>
+                  <label>
+                    <span>Description</span>
+                    <input
+                      type="text"
+                      placeholder="Optional details"
+                      .value=${line.description ?? ''}
+                      @input=${(event: Event) => this.handleDescriptionInput(line.id, event)}
+                    />
+                  </label>
+                </div>
+                <label>
+                  <span>Quantity</span>
+                  <input
+                    type="number"
+                    min="1"
+                    step="1"
+                    .value=${String(line.quantity)}
+                    @input=${(event: Event) => this.handleQuantityInput(line.id, event)}
+                  />
+                </label>
+                <money-input
+                  label="Unit price"
+                  .value=${line.unitPriceCents}
+                  @value-change=${(event: CustomEvent<{ value: number }>) =>
+                    this.handlePriceChange(line.id, event.detail.value)}
+                ></money-input>
+                <div class="line-actions">
+                  <button type="button" @click=${() => this.removeLine(line.id)} aria-label="Remove line">✕</button>
+                </div>
+              </div>
+            `;
+          })}
+          <button type="button" @click=${this.addLine}>➕ Add item</button>
+        </div>
+
+        <div class="totals">
+          <money-input
+            label="Discount"
+            .value=${this.discountCents}
+            @value-change=${(event: CustomEvent<{ value: number }>) => (this.discountCents = event.detail.value)}
+          ></money-input>
+          <money-input
+            label="Tax"
+            .value=${this.taxCents}
+            @value-change=${(event: CustomEvent<{ value: number }>) => (this.taxCents = event.detail.value)}
+          ></money-input>
+        </div>
+
+        <label>
+          <span>Notes</span>
+          <textarea
+            placeholder="Visible on the invoice"
+            .value=${this.notes}
+            @input=${this.handleNotesInput}
+          ></textarea>
+        </label>
+
+        <div class="summary" aria-live="polite">
+          <h3>Invoice summary</h3>
+          <dl>
+            <div>
+              <dt>Subtotal</dt>
+              <dd>${formatCurrency(totals.subTotalCents)}</dd>
+            </div>
+            <div>
+              <dt>Discount</dt>
+              <dd>${formatCurrency(this.discountCents)}</dd>
+            </div>
+            <div>
+              <dt>Tax</dt>
+              <dd>${formatCurrency(this.taxCents)}</dd>
+            </div>
+            <div>
+              <dt>Total due</dt>
+              <dd>${formatCurrency(totals.grandTotalCents)}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <div class="footer">
+          <label>
+            <span>Status</span>
+            <select .value=${this.status} @change=${this.handleStatusChange}>
+              ${invoiceStatusSchema.options.map(status => html`<option value=${status}>${status}</option>`)}
+            </select>
+          </label>
+          <button type="submit" ?disabled=${this.submitting || !this.customer}>
+            ${this.submitting ? 'Saving…' : 'Create invoice'}
+          </button>
+        </div>
+      </form>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'invoice-form': InvoiceForm;
+  }
+}

--- a/apps/web/src/components/money-input.ts
+++ b/apps/web/src/components/money-input.ts
@@ -1,0 +1,162 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
+import { centsToNumber, formatCurrency, numberToCents } from '../utils/format.js';
+
+@customElement('money-input')
+export class MoneyInput extends LitElement {
+  static styles = css`
+    :host {
+      display: inline-flex;
+      flex-direction: column;
+      gap: var(--space-2xs);
+      font-size: 0.9rem;
+    }
+
+    label {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--space-sm);
+      color: var(--color-text-muted);
+      font-weight: 500;
+    }
+
+    .field {
+      position: relative;
+    }
+
+    input {
+      width: 100%;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--color-border);
+      background: var(--color-surface);
+      padding: calc(var(--space-sm) + 1px) calc(var(--space-lg) + 0.5rem);
+      font-size: 1rem;
+      color: var(--color-text);
+      transition: border-color var(--transition-snappy), box-shadow var(--transition-snappy);
+    }
+
+    input:focus-visible {
+      border-color: var(--color-primary);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+      outline: none;
+    }
+
+    .currency {
+      position: absolute;
+      inset: 0 auto 0 var(--space-sm);
+      display: inline-flex;
+      align-items: center;
+      font-weight: 600;
+      color: var(--color-text-muted);
+      pointer-events: none;
+    }
+
+    input::-webkit-outer-spin-button,
+    input::-webkit-inner-spin-button {
+      appearance: none;
+      margin: 0;
+    }
+  `;
+
+  @property({ type: Number })
+  value = 0;
+
+  @property({ type: String })
+  currency = 'USD';
+
+  @property({ type: String })
+  locale = navigator.language || 'en-US';
+
+  @property({ type: String })
+  label = 'Amount';
+
+  @property({ type: String })
+  name?: string;
+
+  @property({ type: Boolean, reflect: true })
+  disabled = false;
+
+  @property({ type: Boolean, reflect: true })
+  readonly = false;
+
+  @property({ type: Boolean, reflect: true })
+  required = false;
+
+  @property({ type: String })
+  placeholder = '0.00';
+
+  @query('input')
+  private inputElement!: HTMLInputElement;
+
+  private format(value: number) {
+    return formatCurrency(value, this.currency, this.locale);
+  }
+
+  private updateDisplayValue() {
+    const input = this.inputElement;
+    if (!input) return;
+    input.value = centsToNumber(this.value).toFixed(2);
+  }
+
+  private handleInput = (event: Event) => {
+    const target = event.target as HTMLInputElement;
+    const clean = target.value.replace(/[^0-9.,-]/g, '');
+    const normalized = clean.replace(/,/g, '.');
+    const parsed = Number.parseFloat(normalized);
+    const cents = numberToCents(Number.isNaN(parsed) ? 0 : parsed);
+    this.value = cents;
+    this.dispatchEvent(
+      new CustomEvent('value-change', {
+        detail: { value: cents },
+        bubbles: true,
+        composed: true
+      })
+    );
+  };
+
+  private handleBlur = () => {
+    this.updateDisplayValue();
+  };
+
+  protected updated(changed: Map<string, unknown>): void {
+    if (changed.has('value')) {
+      this.updateDisplayValue();
+    }
+  }
+
+  protected firstUpdated(): void {
+    this.updateDisplayValue();
+  }
+
+  protected render() {
+    return html`
+      <label>
+        <span>${this.label}</span>
+        <span aria-hidden="true">${this.format(this.value)}</span>
+      </label>
+      <div class="field">
+        <span class="currency" aria-hidden="true">${this.currency}</span>
+        <input
+          type="text"
+          inputmode="decimal"
+          autocomplete="off"
+          .name=${this.name ?? ''}
+          .value=${centsToNumber(this.value).toFixed(2)}
+          placeholder=${this.placeholder}
+          ?disabled=${this.disabled}
+          ?readonly=${this.readonly}
+          ?required=${this.required}
+          @input=${this.handleInput}
+          @blur=${this.handleBlur}
+        />
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'money-input': MoneyInput;
+  }
+}

--- a/apps/web/src/components/pdf-preview.ts
+++ b/apps/web/src/components/pdf-preview.ts
@@ -1,0 +1,146 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { requestInvoicePdf } from '../api/client.js';
+
+@customElement('pdf-preview')
+export class PdfPreview extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-lg);
+      background: var(--color-surface);
+      box-shadow: var(--shadow-sm);
+      overflow: hidden;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: var(--space-sm) var(--space-md);
+      border-bottom: 1px solid var(--color-border);
+      background: linear-gradient(180deg, rgba(37, 99, 235, 0.05), transparent);
+    }
+
+    header h4 {
+      margin: 0;
+      font-size: 0.95rem;
+    }
+
+    header button {
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--color-border);
+      background: var(--color-surface);
+      padding: var(--space-xs) var(--space-sm);
+      font-size: 0.85rem;
+      color: var(--color-text);
+    }
+
+    .viewer {
+      min-height: 320px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: repeating-linear-gradient(45deg, rgba(37, 99, 235, 0.05) 0, rgba(37, 99, 235, 0.05) 10px, transparent 10px, transparent 20px);
+    }
+
+    iframe,
+    embed {
+      width: 100%;
+      min-height: 480px;
+      border: none;
+    }
+
+    .message {
+      padding: var(--space-lg);
+      text-align: center;
+      color: var(--color-text-muted);
+      font-size: 0.9rem;
+    }
+  `;
+
+  @property({ type: Number })
+  invoiceId?: number;
+
+  @property({ type: Boolean })
+  auto = false;
+
+  @state()
+  private objectUrl?: string;
+
+  @state()
+  private loading = false;
+
+  @state()
+  private error?: string;
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.revokeUrl();
+  }
+
+  protected updated(changed: Map<string, unknown>): void {
+    if (changed.has('invoiceId') && this.auto && this.invoiceId) {
+      this.load();
+    }
+  }
+
+  private revokeUrl() {
+    if (this.objectUrl) {
+      URL.revokeObjectURL(this.objectUrl);
+      this.objectUrl = undefined;
+    }
+  }
+
+  private async load() {
+    if (!this.invoiceId) return;
+    this.loading = true;
+    this.error = undefined;
+    try {
+      const blob = await requestInvoicePdf(this.invoiceId);
+      this.revokeUrl();
+      this.objectUrl = URL.createObjectURL(blob);
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : 'Unable to load preview';
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  protected render() {
+    return html`
+      <header>
+        <h4>Invoice preview</h4>
+        <button type="button" @click=${this.load} ?disabled=${this.loading || !this.invoiceId}>
+          ${this.loading ? 'Loading…' : 'Refresh'}
+        </button>
+      </header>
+      <div class="viewer" role="region" aria-live="polite">
+        ${this.renderViewer()}
+      </div>
+    `;
+  }
+
+  private renderViewer() {
+    if (this.loading) {
+      return html`<div class="message">Preparing preview…</div>`;
+    }
+
+    if (this.error) {
+      return html`<div class="message" role="alert">${this.error}</div>`;
+    }
+
+    if (!this.objectUrl) {
+      return html`<div class="message">Generate an invoice to preview the PDF.</div>`;
+    }
+
+    return html`<embed src=${this.objectUrl} type="application/pdf" />`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'pdf-preview': PdfPreview;
+  }
+}

--- a/apps/web/src/components/product-picker.ts
+++ b/apps/web/src/components/product-picker.ts
@@ -1,0 +1,254 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import type { Product } from '../api/client.js';
+import { formatCurrency } from '../utils/format.js';
+
+@customElement('product-picker')
+export class ProductPicker extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    label {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2xs);
+      font-size: 0.85rem;
+      color: var(--color-text-muted);
+    }
+
+    .input-wrapper {
+      position: relative;
+    }
+
+    input[type='search'] {
+      width: 100%;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--color-border);
+      background: var(--color-surface);
+      padding: calc(var(--space-sm) + 1px) var(--space-lg);
+      font-size: 0.95rem;
+      transition: border-color var(--transition-snappy), box-shadow var(--transition-snappy);
+    }
+
+    input[type='search']:focus-visible {
+      border-color: var(--color-primary);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+      outline: none;
+    }
+
+    ul {
+      margin: var(--space-xs) 0 0;
+      padding: 0;
+      list-style: none;
+      max-height: 240px;
+      overflow-y: auto;
+      border-radius: var(--radius-md);
+      border: 1px solid var(--color-border);
+      background: var(--color-surface);
+      box-shadow: var(--shadow-sm);
+    }
+
+    li + li {
+      border-top: 1px solid rgba(215, 222, 234, 0.7);
+    }
+
+    button.option {
+      width: 100%;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: var(--space-sm);
+      padding: var(--space-sm) var(--space-md);
+      background: none;
+      border: none;
+      text-align: left;
+      font-size: 0.9rem;
+      color: var(--color-text);
+    }
+
+    button.option[aria-selected='true'] {
+      background: rgba(37, 99, 235, 0.1);
+      color: var(--color-primary);
+    }
+
+    .meta {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .sku {
+      font-size: 0.75rem;
+      color: var(--color-text-muted);
+    }
+
+    .empty-state {
+      padding: var(--space-sm) var(--space-md);
+      color: var(--color-text-muted);
+      font-size: 0.85rem;
+    }
+  `;
+
+  @property({ attribute: false })
+  products: Product[] = [];
+
+  @property({ type: Number })
+  value?: number;
+
+  @property({ type: String })
+  label = 'Product';
+
+  @property({ type: Boolean })
+  disabled = false;
+
+  @state()
+  private query = '';
+
+  @state()
+  private activeIndex = 0;
+
+  get filteredProducts() {
+    const search = this.query.trim().toLowerCase();
+    if (!search) return this.products;
+    return this.products.filter(product => {
+      const haystack = `${product.sku} ${product.name}`.toLowerCase();
+      return haystack.includes(search);
+    });
+  }
+
+  private selectProduct(product: Product) {
+    this.value = product.id;
+    this.query = `${product.sku} — ${product.name}`;
+    this.activeIndex = this.filteredProducts.findIndex(item => item.id === product.id);
+    this.dispatchEvent(
+      new CustomEvent('product-select', {
+        detail: { product },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  private handleInput = (event: Event) => {
+    const target = event.target as HTMLInputElement;
+    this.query = target.value;
+    this.activeIndex = 0;
+  };
+
+  private handleFocus = (event: FocusEvent) => {
+    const target = event.target as HTMLInputElement;
+    if (!target.value && this.value) {
+      const product = this.products.find(item => item.id === this.value);
+      if (product) {
+        this.query = `${product.sku} — ${product.name}`;
+      }
+    }
+  };
+
+  private handleKeydown = (event: KeyboardEvent) => {
+    const products = this.filteredProducts;
+    if (!products.length) return;
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      this.activeIndex = (this.activeIndex + 1) % products.length;
+      this.scrollIntoView(this.activeIndex);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      this.activeIndex = (this.activeIndex - 1 + products.length) % products.length;
+      this.scrollIntoView(this.activeIndex);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      const product = products[this.activeIndex];
+      if (product) {
+        this.selectProduct(product);
+      }
+    }
+  };
+
+  private scrollIntoView(index: number) {
+    const list = this.renderRoot.querySelector('ul');
+    const item = list?.children[index] as HTMLElement | undefined;
+    if (list && item) {
+      const itemTop = item.offsetTop;
+      const itemBottom = itemTop + item.offsetHeight;
+      if (itemTop < list.scrollTop) {
+        list.scrollTop = itemTop;
+      } else if (itemBottom > list.scrollTop + list.clientHeight) {
+        list.scrollTop = itemBottom - list.clientHeight;
+      }
+    }
+  }
+
+  protected updated(changed: Map<string, unknown>): void {
+    if (changed.has('value')) {
+      const product = this.products.find(item => item.id === this.value);
+      if (product) {
+        this.query = `${product.sku} — ${product.name}`;
+        const index = this.filteredProducts.findIndex(item => item.id === product.id);
+        if (index >= 0) {
+          this.activeIndex = index;
+        }
+      }
+    }
+  }
+
+  protected render() {
+    const products = this.filteredProducts;
+    return html`
+      <label>
+        <span>${this.label}</span>
+        <div class="input-wrapper">
+          <input
+            type="search"
+            role="combobox"
+            aria-autocomplete="list"
+            aria-expanded="true"
+            aria-controls="product-list"
+            aria-activedescendant=${products[this.activeIndex]?.id ?? ''}
+            placeholder="Search products"
+            ?disabled=${this.disabled}
+            .value=${this.query}
+            @input=${this.handleInput}
+            @keydown=${this.handleKeydown}
+            @focus=${this.handleFocus}
+          />
+        </div>
+      </label>
+      <ul id="product-list" role="listbox">
+        ${products.length
+          ? products.map((product, index) => {
+              const selected = product.id === this.value;
+              const active = index === this.activeIndex;
+              return html`
+                <li>
+                  <button
+                    type="button"
+                    class="option"
+                    role="option"
+                    id=${String(product.id)}
+                    aria-selected=${selected || active}
+                    @click=${() => this.selectProduct(product)}
+                  >
+                    <span class="meta">
+                      <strong>${product.name}</strong>
+                      <span class="sku">${product.sku}</span>
+                    </span>
+                    <span>${formatCurrency(product.unitPriceCents)}</span>
+                  </button>
+                </li>
+              `;
+            })
+          : html`<li class="empty-state" role="presentation">No products match “${this.query}”.</li>`}
+      </ul>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'product-picker': ProductPicker;
+  }
+}

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1,1 +1,2 @@
+import './styles/global.css';
 import './root-app';

--- a/apps/web/src/pages/customers-page.ts
+++ b/apps/web/src/pages/customers-page.ts
@@ -1,0 +1,295 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import {
+  createCustomer,
+  fetchCustomers,
+  type Customer,
+  type CustomerCreateInput,
+  type CustomerListResponse
+} from '../api/client.js';
+import '../components/customer-list.js';
+import { formatRelativeDate } from '../utils/format.js';
+
+@customElement('customers-page')
+export class CustomersPage extends LitElement {
+  static styles = css`
+    :host {
+      display: grid;
+      gap: var(--space-xl);
+    }
+
+    .layout {
+      display: grid;
+      grid-template-columns: minmax(320px, 420px) 1fr;
+      gap: var(--space-xl);
+    }
+
+    form {
+      display: grid;
+      gap: var(--space-sm);
+      background: var(--color-surface);
+      padding: var(--space-xl);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow-sm);
+      border: 1px solid var(--color-border);
+    }
+
+    form h3 {
+      margin: 0;
+      font-size: 1.1rem;
+      letter-spacing: -0.01em;
+    }
+
+    label {
+      display: grid;
+      gap: var(--space-2xs);
+      font-size: 0.85rem;
+      color: var(--color-text-muted);
+    }
+
+    input,
+    textarea {
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--color-border);
+      padding: var(--space-sm) var(--space-md);
+      font-size: 0.95rem;
+    }
+
+    textarea {
+      min-height: 90px;
+      resize: vertical;
+    }
+
+    button[type='submit'] {
+      margin-top: var(--space-md);
+      border-radius: var(--radius-md);
+      background: var(--color-primary);
+      color: white;
+      border: 1px solid var(--color-primary-strong);
+      padding: var(--space-sm) var(--space-lg);
+      font-size: 0.95rem;
+      box-shadow: 0 8px 24px rgba(37, 99, 235, 0.2);
+    }
+
+    .details {
+      display: grid;
+      gap: var(--space-lg);
+      background: var(--color-surface);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow-sm);
+      padding: var(--space-xl);
+      border: 1px solid var(--color-border);
+    }
+
+    .details h3 {
+      margin: 0;
+      font-size: 1.2rem;
+    }
+
+    .details dl {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: var(--space-sm) var(--space-lg);
+      margin: 0;
+    }
+
+    .details dt {
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--color-text-muted);
+    }
+
+    .details dd {
+      margin: 0;
+      font-weight: 600;
+    }
+
+    .actions {
+      display: flex;
+      gap: var(--space-sm);
+    }
+
+    .actions button {
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--color-border);
+      background: var(--color-surface-strong);
+      padding: var(--space-sm) var(--space-md);
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 980px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+    }
+  `;
+
+  @state()
+  private customers: Customer[] = [];
+
+  @state()
+  private pagination?: CustomerListResponse['pagination'];
+
+  @state()
+  private loading = false;
+
+  @state()
+  private creating = false;
+
+  @state()
+  private selected?: Customer;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.load();
+  }
+
+  private async load() {
+    this.loading = true;
+    try {
+      const response = await fetchCustomers({ limit: 20, sort: 'createdAt' });
+      this.customers = response.data;
+      this.pagination = response.pagination;
+      if (!this.selected && response.data.length) {
+        this.selected = response.data[0];
+      }
+    } catch (error) {
+      console.error('Failed to load customers', error);
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private async handleCreate(event: Event) {
+    event.preventDefault();
+    const form = event.target as HTMLFormElement;
+    const formData = new FormData(form);
+    const payload: CustomerCreateInput = {
+      name: String(formData.get('name') ?? '').trim(),
+      email: (formData.get('email') as string | null)?.trim() || undefined,
+      phone: (formData.get('phone') as string | null)?.trim() || undefined,
+      address: (formData.get('address') as string | null)?.trim() || undefined
+    };
+
+    if (!payload.name) return;
+
+    const optimistic: Customer = {
+      id: Date.now() * -1,
+      name: payload.name,
+      email: payload.email,
+      phone: payload.phone,
+      address: payload.address,
+      createdAt: new Date().toISOString()
+    };
+
+    this.creating = true;
+    this.customers = [optimistic, ...this.customers];
+    this.selected = optimistic;
+    form.reset();
+
+    try {
+      const created = await createCustomer(payload);
+      this.customers = [created, ...this.customers.filter(customer => customer.id !== optimistic.id)];
+      this.selected = created;
+    } catch (error) {
+      console.error('Failed to create customer', error);
+      this.customers = this.customers.filter(customer => customer.id !== optimistic.id);
+    } finally {
+      this.creating = false;
+    }
+  }
+
+  private handleSelect(event: CustomEvent<{ customer: Customer }>) {
+    this.selected = event.detail.customer;
+  }
+
+  private goToInvoice() {
+    if (!this.selected) return;
+    this.dispatchEvent(
+      new CustomEvent('navigate', {
+        detail: `/invoices/new?customerId=${this.selected.id}`,
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  private goToPayments() {
+    if (!this.selected) return;
+    this.dispatchEvent(
+      new CustomEvent('navigate', {
+        detail: `/payments?customer=${this.selected.id}`,
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  protected render() {
+    return html`
+      <div class="layout">
+        <customer-list
+          .customers=${this.customers}
+          .selectedId=${this.selected?.id}
+          .loading=${this.loading}
+          @customer-selected=${this.handleSelect}
+        ></customer-list>
+        <div class="details">
+          <div>
+            <h3>${this.selected?.name ?? 'Select a customer'}</h3>
+            ${this.selected
+              ? html`<p>Customer since ${formatRelativeDate(this.selected.createdAt)}</p>`
+              : html`<p>Pick a customer to view contact information and quick actions.</p>`}
+          </div>
+          ${this.selected
+            ? html`<dl>
+                <div>
+                  <dt>Email</dt>
+                  <dd>${this.selected.email ?? '—'}</dd>
+                </div>
+                <div>
+                  <dt>Phone</dt>
+                  <dd>${this.selected.phone ?? '—'}</dd>
+                </div>
+                <div>
+                  <dt>Address</dt>
+                  <dd>${this.selected.address ?? '—'}</dd>
+                </div>
+              </dl>
+              <div class="actions">
+                <button type="button" @click=${this.goToInvoice}>Start invoice</button>
+                <button type="button" @click=${this.goToPayments}>Record payment</button>
+              </div>`
+            : null}
+        </div>
+      </div>
+      <form @submit=${(event: Event) => this.handleCreate(event)}>
+        <h3>Add a customer</h3>
+        <label>
+          <span>Name</span>
+          <input name="name" required placeholder="Acme Studios" />
+        </label>
+        <label>
+          <span>Email</span>
+          <input type="email" name="email" placeholder="team@example.com" />
+        </label>
+        <label>
+          <span>Phone</span>
+          <input name="phone" placeholder="+1 555 123 4567" />
+        </label>
+        <label>
+          <span>Address</span>
+          <textarea name="address" placeholder="Street, City, ZIP"></textarea>
+        </label>
+        <button type="submit" ?disabled=${this.creating}>${this.creating ? 'Creating…' : 'Save customer'}</button>
+      </form>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'customers-page': CustomersPage;
+  }
+}

--- a/apps/web/src/pages/dashboard-page.ts
+++ b/apps/web/src/pages/dashboard-page.ts
@@ -1,0 +1,296 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import Chart from 'chart.js/auto';
+import {
+  fetchCustomers,
+  fetchDuesReport,
+  fetchSalesReport,
+  type CustomerListResponse,
+  type DuesReport,
+  type SalesReport
+} from '../api/client.js';
+import { formatCurrency, formatDate } from '../utils/format.js';
+
+@customElement('dashboard-page')
+export class DashboardPage extends LitElement {
+  static styles = css`
+    :host {
+      display: grid;
+      gap: var(--space-2xl);
+    }
+
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: var(--space-lg);
+    }
+
+    .card {
+      padding: var(--space-xl);
+      border-radius: var(--radius-lg);
+      background: var(--color-surface);
+      box-shadow: var(--shadow-md);
+      border: 1px solid rgba(37, 99, 235, 0.12);
+      display: grid;
+      gap: var(--space-sm);
+    }
+
+    .card h3 {
+      margin: 0;
+      font-size: 0.9rem;
+      color: var(--color-text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .card strong {
+      font-size: 1.8rem;
+      letter-spacing: -0.02em;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: var(--space-2xl);
+    }
+
+    canvas {
+      width: 100% !important;
+      height: 320px !important;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--color-surface);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow-sm);
+      overflow: hidden;
+    }
+
+    th,
+    td {
+      padding: var(--space-md) var(--space-lg);
+      text-align: left;
+      border-bottom: 1px solid var(--color-border);
+      font-size: 0.9rem;
+    }
+
+    th {
+      text-transform: uppercase;
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      color: var(--color-text-muted);
+      background: rgba(37, 99, 235, 0.08);
+    }
+
+    tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    .loading {
+      padding: var(--space-xl);
+      text-align: center;
+      color: var(--color-text-muted);
+    }
+  `;
+
+  @state()
+  private duesReport?: DuesReport;
+
+  @state()
+  private salesReport?: SalesReport;
+
+  @state()
+  private customerList?: CustomerListResponse;
+
+  @state()
+  private loading = false;
+
+  private duesChart?: Chart;
+  private salesChart?: Chart;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.refresh();
+  }
+
+  disconnectedCallback(): void {
+    this.duesChart?.destroy();
+    this.salesChart?.destroy();
+    super.disconnectedCallback();
+  }
+
+  private async refresh() {
+    this.loading = true;
+    try {
+      const [dues, sales, customers] = await Promise.all([
+        fetchDuesReport(),
+        fetchSalesReport({ groupBy: 'month' }),
+        fetchCustomers({ limit: 5, sort: 'createdAt' })
+      ]);
+      this.duesReport = dues;
+      this.salesReport = sales;
+      this.customerList = customers;
+    } catch (error) {
+      console.error('Failed to load dashboard', error);
+    } finally {
+      this.loading = false;
+      this.updateComplete.then(() => {
+        this.renderCharts();
+      });
+    }
+  }
+
+  protected updated(changed: Map<string, unknown>): void {
+    if (changed.has('duesReport') || changed.has('salesReport')) {
+      this.renderCharts();
+    }
+  }
+
+  private renderCharts() {
+    const salesCanvas = this.renderRoot.querySelector<HTMLCanvasElement>('#sales-chart');
+    if (salesCanvas && this.salesReport) {
+      this.salesChart?.destroy();
+      this.salesChart = new Chart(salesCanvas, {
+        type: 'line',
+        data: {
+          labels: this.salesReport.rows.map(row => row.period),
+          datasets: [
+            {
+              label: 'Sales',
+              data: this.salesReport.rows.map(row => row.totalCents / 100),
+              borderColor: '#2563eb',
+              backgroundColor: 'rgba(37, 99, 235, 0.25)',
+              tension: 0.35,
+              fill: true,
+              pointRadius: 4
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          plugins: {
+            legend: { display: false }
+          },
+          scales: {
+            y: {
+              ticks: {
+                callback: value => `$${value}`
+              }
+            }
+          }
+        }
+      });
+    }
+
+    const duesCanvas = this.renderRoot.querySelector<HTMLCanvasElement>('#dues-chart');
+    if (duesCanvas && this.duesReport) {
+      this.duesChart?.destroy();
+      const top = [...this.duesReport.customers]
+        .sort((a, b) => b.balanceCents - a.balanceCents)
+        .slice(0, 6);
+      this.duesChart = new Chart(duesCanvas, {
+        type: 'doughnut',
+        data: {
+          labels: top.map(item => item.customerName),
+          datasets: [
+            {
+              label: 'Outstanding',
+              data: top.map(item => item.balanceCents / 100),
+              backgroundColor: ['#2563eb', '#7c3aed', '#f97316', '#ef4444', '#10b981', '#0ea5e9'],
+              borderWidth: 0
+            }
+          ]
+        },
+        options: {
+          plugins: {
+            legend: { position: 'bottom' as const }
+          }
+        }
+      });
+    }
+  }
+
+  private get totalOutstanding() {
+    if (!this.duesReport) return 0;
+    return this.duesReport.customers.reduce((sum, item) => sum + item.balanceCents, 0);
+  }
+
+  private get totalInvoiced() {
+    if (!this.duesReport) return 0;
+    return this.duesReport.customers.reduce((sum, item) => sum + item.invoicedCents, 0);
+  }
+
+  private get totalPaid() {
+    if (!this.duesReport) return 0;
+    return this.duesReport.customers.reduce((sum, item) => sum + item.paidCents, 0);
+  }
+
+  private get latestCustomers() {
+    return this.customerList?.data ?? [];
+  }
+
+  protected render() {
+    if (this.loading && !this.duesReport) {
+      return html`<div class="loading">Loading dashboard…</div>`;
+    }
+
+    return html`
+      <section class="cards" aria-live="polite">
+        <article class="card">
+          <h3>Outstanding dues</h3>
+          <strong>${formatCurrency(this.totalOutstanding)}</strong>
+          <span>Across ${this.duesReport?.customers.length ?? 0} customers</span>
+        </article>
+        <article class="card">
+          <h3>Total invoiced</h3>
+          <strong>${formatCurrency(this.totalInvoiced)}</strong>
+        </article>
+        <article class="card">
+          <h3>Total collected</h3>
+          <strong>${formatCurrency(this.totalPaid)}</strong>
+        </article>
+      </section>
+
+      <section class="grid">
+        <article>
+          <h3>Sales trend</h3>
+          <canvas id="sales-chart" role="img" aria-label="Sales trend chart"></canvas>
+        </article>
+        <article>
+          <h3>Top dues</h3>
+          <canvas id="dues-chart" role="img" aria-label="Outstanding dues per customer"></canvas>
+        </article>
+      </section>
+
+      <section>
+        <h3>Recent customers</h3>
+        ${this.latestCustomers.length
+          ? html`<table>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Email</th>
+                  <th>Joined</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${this.latestCustomers.map(customer => html`<tr>
+                    <td>${customer.name}</td>
+                    <td>${customer.email ?? '—'}</td>
+                    <td>${formatDate(customer.createdAt, undefined, { dateStyle: 'medium' })}</td>
+                  </tr>`)}
+              </tbody>
+            </table>`
+          : html`<div class="loading">No customers yet. Add your first customer to get started.</div>`}
+      </section>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'dashboard-page': DashboardPage;
+  }
+}

--- a/apps/web/src/pages/invoice-editor-page.ts
+++ b/apps/web/src/pages/invoice-editor-page.ts
@@ -1,0 +1,249 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import {
+  createInvoice,
+  fetchCustomers,
+  fetchProducts,
+  type Customer,
+  type CustomerListResponse,
+  type Invoice
+} from '../api/client.js';
+import '../components/invoice-form.js';
+import '../components/pdf-preview.js';
+import '../components/customer-list.js';
+import type { InvoiceCreateInput } from '@stationery/shared';
+import { formatCurrency } from '../utils/format.js';
+
+@customElement('invoice-editor-page')
+export class InvoiceEditorPage extends LitElement {
+  static styles = css`
+    :host {
+      display: grid;
+      gap: var(--space-xl);
+    }
+
+    .layout {
+      display: grid;
+      grid-template-columns: minmax(320px, 360px) 1fr;
+      gap: var(--space-xl);
+    }
+
+    .summary {
+      background: var(--color-surface);
+      border-radius: var(--radius-lg);
+      border: 1px solid var(--color-border);
+      padding: var(--space-xl);
+      box-shadow: var(--shadow-sm);
+      display: grid;
+      gap: var(--space-md);
+    }
+
+    .summary h3 {
+      margin: 0;
+      font-size: 1.2rem;
+    }
+
+    .summary dl {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: var(--space-sm) var(--space-lg);
+      margin: 0;
+    }
+
+    .summary dt {
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--color-text-muted);
+    }
+
+    .summary dd {
+      margin: 0;
+      font-weight: 600;
+    }
+
+    .success {
+      border-radius: var(--radius-lg);
+      padding: var(--space-lg);
+      background: rgba(22, 163, 74, 0.1);
+      border: 1px solid rgba(22, 163, 74, 0.3);
+      color: var(--color-positive);
+    }
+
+    .actions {
+      display: flex;
+      gap: var(--space-sm);
+      flex-wrap: wrap;
+    }
+
+    .actions button {
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--color-border);
+      background: var(--color-surface-strong);
+      padding: var(--space-sm) var(--space-md);
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 1000px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+    }
+  `;
+
+  @property({ type: Number })
+  prefillCustomerId?: number;
+
+  @state()
+  private customers: Customer[] = [];
+
+  @state()
+  private products: Awaited<ReturnType<typeof fetchProducts>>['data'] = [];
+
+  @state()
+  private selectedCustomer?: Customer;
+
+  @state()
+  private submitting = false;
+
+  @state()
+  private lastInvoice?: Invoice;
+
+  @state()
+  private customerPagination?: CustomerListResponse['pagination'];
+
+  @state()
+  private loading = false;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.load();
+  }
+
+  protected updated(changed: Map<string, unknown>): void {
+    if (changed.has('prefillCustomerId') && this.prefillCustomerId) {
+      const found = this.customers.find(customer => customer.id === this.prefillCustomerId);
+      if (found) {
+        this.selectedCustomer = found;
+      }
+    }
+  }
+
+  private async load() {
+    this.loading = true;
+    try {
+      const [customerResponse, productResponse] = await Promise.all([
+        fetchCustomers({ limit: 100, sort: 'name', direction: 'asc' }),
+        fetchProducts({ limit: 100, sort: 'name', direction: 'asc' })
+      ]);
+      this.customers = customerResponse.data;
+      this.customerPagination = customerResponse.pagination;
+      this.products = productResponse.data;
+      if (!this.selectedCustomer && this.prefillCustomerId) {
+        this.selectedCustomer = this.customers.find(customer => customer.id === this.prefillCustomerId);
+      }
+      if (!this.selectedCustomer && this.customers.length) {
+        this.selectedCustomer = this.customers[0];
+      }
+    } catch (error) {
+      console.error('Failed to load invoice editor data', error);
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private handleCustomerSelect(event: CustomEvent<{ customer: Customer }>) {
+    this.selectedCustomer = event.detail.customer;
+  }
+
+  private async handleSubmit(event: CustomEvent<InvoiceCreateInput>) {
+    if (!this.selectedCustomer) return;
+    this.submitting = true;
+    try {
+      const invoice = await createInvoice(event.detail);
+      this.lastInvoice = invoice;
+      this.dispatchEvent(
+        new CustomEvent('toast', {
+          detail: { message: 'Invoice created successfully', type: 'success' },
+          bubbles: true,
+          composed: true
+        })
+      );
+    } catch (error) {
+      console.error('Failed to create invoice', error);
+    } finally {
+      this.submitting = false;
+    }
+  }
+
+  private goToPayments() {
+    if (!this.lastInvoice) return;
+    this.dispatchEvent(
+      new CustomEvent('navigate', {
+        detail: `/payments?invoice=${this.lastInvoice.id}`,
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  private goToPdf() {
+    if (!this.lastInvoice) return;
+    this.dispatchEvent(
+      new CustomEvent('navigate', {
+        detail: `/reports?invoice=${this.lastInvoice.id}`,
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  protected render() {
+    return html`
+      <div class="layout">
+        <customer-list
+          .customers=${this.customers}
+          .selectedId=${this.selectedCustomer?.id}
+          .loading=${this.loading}
+          @customer-selected=${this.handleCustomerSelect}
+        ></customer-list>
+        <invoice-form
+          .customer=${this.selectedCustomer}
+          .products=${this.products}
+          .submitting=${this.submitting}
+          @invoice-submit=${this.handleSubmit}
+        ></invoice-form>
+      </div>
+      ${this.lastInvoice
+        ? html`<section class="summary">
+            <div class="success">Invoice ${this.lastInvoice.invoiceNo} created.</div>
+            <dl>
+              <div>
+                <dt>Customer</dt>
+                <dd>${this.lastInvoice.customer?.name ?? this.selectedCustomer?.name ?? '—'}</dd>
+              </div>
+              <div>
+                <dt>Total</dt>
+                <dd>${formatCurrency(this.lastInvoice.grandTotalCents)}</dd>
+              </div>
+              <div>
+                <dt>Status</dt>
+                <dd>${this.lastInvoice.status}</dd>
+              </div>
+            </dl>
+            <div class="actions">
+              <button type="button" @click=${this.goToPayments}>Record payment</button>
+              <button type="button" @click=${this.goToPdf}>Reports</button>
+            </div>
+            <pdf-preview .invoiceId=${this.lastInvoice.id} auto></pdf-preview>
+          </section>`
+        : null}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'invoice-editor-page': InvoiceEditorPage;
+  }
+}

--- a/apps/web/src/pages/payments-page.ts
+++ b/apps/web/src/pages/payments-page.ts
@@ -1,0 +1,257 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import {
+  createPayment,
+  fetchCustomers,
+  fetchInvoices,
+  fetchPayments,
+  type Customer,
+  type Invoice,
+  type Payment,
+  type PaymentCreateInput
+} from '../api/client.js';
+import { formatCurrency, formatDate } from '../utils/format.js';
+
+@customElement('payments-page')
+export class PaymentsPage extends LitElement {
+  static styles = css`
+    :host {
+      display: grid;
+      gap: var(--space-xl);
+    }
+
+    .layout {
+      display: grid;
+      grid-template-columns: minmax(320px, 360px) 1fr;
+      gap: var(--space-xl);
+    }
+
+    form {
+      display: grid;
+      gap: var(--space-sm);
+      background: var(--color-surface);
+      padding: var(--space-xl);
+      border-radius: var(--radius-lg);
+      border: 1px solid var(--color-border);
+      box-shadow: var(--shadow-sm);
+    }
+
+    form h3 {
+      margin: 0;
+      font-size: 1.1rem;
+    }
+
+    label {
+      display: grid;
+      gap: var(--space-2xs);
+      font-size: 0.85rem;
+      color: var(--color-text-muted);
+    }
+
+    select,
+    input,
+    textarea {
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--color-border);
+      padding: var(--space-sm) var(--space-md);
+      font-size: 0.95rem;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--color-surface);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow-sm);
+      overflow: hidden;
+    }
+
+    th,
+    td {
+      padding: var(--space-md) var(--space-lg);
+      text-align: left;
+      border-bottom: 1px solid var(--color-border);
+      font-size: 0.9rem;
+    }
+
+    th {
+      text-transform: uppercase;
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      color: var(--color-text-muted);
+      background: rgba(37, 99, 235, 0.08);
+    }
+
+    tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    button[type='submit'] {
+      margin-top: var(--space-md);
+      border-radius: var(--radius-md);
+      background: var(--color-primary);
+      color: white;
+      border: 1px solid var(--color-primary-strong);
+      padding: var(--space-sm) var(--space-lg);
+      font-size: 0.95rem;
+      box-shadow: 0 8px 24px rgba(37, 99, 235, 0.2);
+    }
+
+    @media (max-width: 980px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+    }
+  `;
+
+  @property({ type: Number })
+  customer?: number;
+
+  @state()
+  private payments: Payment[] = [];
+
+  @state()
+  private customers: Customer[] = [];
+
+  @state()
+  private invoices: Invoice[] = [];
+
+  @state()
+  private creating = false;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.load();
+  }
+
+  private async load() {
+    try {
+      const [payments, customers, invoices] = await Promise.all([
+        fetchPayments({ limit: 50, direction: 'desc' }),
+        fetchCustomers({ limit: 100, sort: 'name', direction: 'asc' }),
+        fetchInvoices({ limit: 100, sort: 'issueDate', direction: 'desc' })
+      ]);
+      this.payments = payments.data;
+      this.customers = customers.data;
+      this.invoices = invoices.data;
+    } catch (error) {
+      console.error('Failed to load payments data', error);
+    }
+  }
+
+  private async handleSubmit(event: Event) {
+    event.preventDefault();
+    const form = event.target as HTMLFormElement;
+    const formData = new FormData(form);
+    const customerId = Number.parseInt(String(formData.get('customerId') ?? '0'), 10);
+    if (!Number.isFinite(customerId) || customerId <= 0) return;
+
+    const invoiceIdRaw = String(formData.get('invoiceId') ?? '');
+    const invoiceId = invoiceIdRaw ? Number.parseInt(invoiceIdRaw, 10) : undefined;
+
+    const amount = Number.parseInt(String(formData.get('amountCents') ?? '0'), 10);
+
+    const payload: PaymentCreateInput = {
+      customerId,
+      invoiceId: invoiceId && Number.isFinite(invoiceId) ? invoiceId : undefined,
+      amountCents: Number.isNaN(amount) ? 0 : amount,
+      method: (formData.get('method') as PaymentCreateInput['method']) ?? 'cash',
+      note: (formData.get('note') as string | null)?.trim() || undefined
+    };
+
+    if (payload.amountCents <= 0) return;
+
+    this.creating = true;
+    const optimistic: Payment = {
+      id: Date.now() * -1,
+      ...payload,
+      paidAt: new Date().toISOString()
+    };
+    this.payments = [optimistic, ...this.payments];
+    form.reset();
+
+    try {
+      const created = await createPayment(payload);
+      this.payments = [created, ...this.payments.filter(payment => payment.id !== optimistic.id)];
+    } catch (error) {
+      console.error('Failed to create payment', error);
+      this.payments = this.payments.filter(payment => payment.id !== optimistic.id);
+    } finally {
+      this.creating = false;
+    }
+  }
+
+  protected render() {
+    return html`
+      <div class="layout">
+        <form @submit=${(event: Event) => this.handleSubmit(event)}>
+          <h3>Record payment</h3>
+          <label>
+            <span>Customer</span>
+            <select name="customerId" required .value=${String(this.customer ?? '')}>
+              <option value="">Select customer</option>
+              ${this.customers.map(customer => html`<option value=${customer.id}>${customer.name}</option>`)}
+            </select>
+          </label>
+          <label>
+            <span>Invoice</span>
+            <select name="invoiceId">
+              <option value="">Unallocated</option>
+              ${this.invoices.map(invoice => html`<option value=${invoice.id}>${invoice.invoiceNo}</option>`)}
+            </select>
+          </label>
+          <label>
+            <span>Amount (cents)</span>
+            <input name="amountCents" type="number" min="1" step="1" required />
+          </label>
+          <label>
+            <span>Method</span>
+            <select name="method">
+              <option value="cash">Cash</option>
+              <option value="bkash">bKash</option>
+              <option value="card">Card</option>
+              <option value="other">Other</option>
+            </select>
+          </label>
+          <label>
+            <span>Note</span>
+            <textarea name="note" placeholder="Optional"></textarea>
+          </label>
+          <button type="submit" ?disabled=${this.creating}>${this.creating ? 'Saving…' : 'Save payment'}</button>
+        </form>
+        <div>
+          <table>
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Customer</th>
+                <th>Invoice</th>
+                <th>Amount</th>
+                <th>Method</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${this.payments.map(payment => {
+                const customer = this.customers.find(item => item.id === payment.customerId);
+                const invoice = this.invoices.find(item => item.id === payment.invoiceId);
+                return html`<tr>
+                  <td>${formatDate(payment.paidAt, undefined, { dateStyle: 'medium', timeStyle: 'short' })}</td>
+                  <td>${customer?.name ?? payment.customerId}</td>
+                  <td>${invoice?.invoiceNo ?? '—'}</td>
+                  <td>${formatCurrency(payment.amountCents)}</td>
+                  <td>${payment.method}</td>
+                </tr>`;
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'payments-page': PaymentsPage;
+  }
+}

--- a/apps/web/src/pages/products-page.ts
+++ b/apps/web/src/pages/products-page.ts
@@ -1,0 +1,229 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import {
+  createProduct,
+  fetchProducts,
+  type Product,
+  type ProductCreateInput,
+  type ProductListResponse
+} from '../api/client.js';
+import { formatCurrency, formatDate } from '../utils/format.js';
+
+@customElement('products-page')
+export class ProductsPage extends LitElement {
+  static styles = css`
+    :host {
+      display: grid;
+      gap: var(--space-xl);
+    }
+
+    .layout {
+      display: grid;
+      grid-template-columns: minmax(320px, 360px) 1fr;
+      gap: var(--space-xl);
+    }
+
+    form {
+      display: grid;
+      gap: var(--space-sm);
+      background: var(--color-surface);
+      padding: var(--space-xl);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow-sm);
+      border: 1px solid var(--color-border);
+    }
+
+    form h3 {
+      margin: 0;
+      font-size: 1.1rem;
+    }
+
+    label {
+      display: grid;
+      gap: var(--space-2xs);
+      font-size: 0.85rem;
+      color: var(--color-text-muted);
+    }
+
+    input,
+    textarea {
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--color-border);
+      padding: var(--space-sm) var(--space-md);
+      font-size: 0.95rem;
+    }
+
+    textarea {
+      min-height: 90px;
+      resize: vertical;
+    }
+
+    button[type='submit'] {
+      margin-top: var(--space-md);
+      border-radius: var(--radius-md);
+      background: var(--color-primary);
+      color: white;
+      border: 1px solid var(--color-primary-strong);
+      padding: var(--space-sm) var(--space-lg);
+      font-size: 0.95rem;
+      box-shadow: 0 8px 24px rgba(37, 99, 235, 0.2);
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--color-surface);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow-sm);
+      overflow: hidden;
+    }
+
+    th,
+    td {
+      padding: var(--space-md) var(--space-lg);
+      text-align: left;
+      border-bottom: 1px solid var(--color-border);
+      font-size: 0.9rem;
+    }
+
+    th {
+      text-transform: uppercase;
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      color: var(--color-text-muted);
+      background: rgba(37, 99, 235, 0.08);
+    }
+
+    tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    @media (max-width: 980px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+    }
+  `;
+
+  @state()
+  private products: Product[] = [];
+
+  @state()
+  private pagination?: ProductListResponse['pagination'];
+
+  @state()
+  private creating = false;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.load();
+  }
+
+  private async load() {
+    try {
+      const response = await fetchProducts({ limit: 50, sort: 'createdAt' });
+      this.products = response.data;
+      this.pagination = response.pagination;
+    } catch (error) {
+      console.error('Failed to load products', error);
+    }
+  }
+
+  private async handleCreate(event: Event) {
+    event.preventDefault();
+    const form = event.target as HTMLFormElement;
+    const formData = new FormData(form);
+    const price = Number.parseInt(String(formData.get('unitPriceCents') ?? '0'), 10);
+    const stock = Number.parseInt(String(formData.get('stockQty') ?? '0'), 10);
+
+    const payload: ProductCreateInput = {
+      sku: String(formData.get('sku') ?? '').trim(),
+      name: String(formData.get('name') ?? '').trim(),
+      description: (formData.get('description') as string | null)?.trim() || undefined,
+      unitPriceCents: Number.isNaN(price) ? 0 : price,
+      stockQty: Number.isNaN(stock) ? 0 : Math.max(0, stock)
+    };
+
+    if (!payload.sku || !payload.name) return;
+
+    this.creating = true;
+    const optimistic: Product = {
+      id: Date.now() * -1,
+      ...payload,
+      createdAt: new Date().toISOString()
+    };
+    this.products = [optimistic, ...this.products];
+    form.reset();
+
+    try {
+      const created = await createProduct(payload);
+      this.products = [created, ...this.products.filter(product => product.id !== optimistic.id)];
+    } catch (error) {
+      console.error('Failed to create product', error);
+      this.products = this.products.filter(product => product.id !== optimistic.id);
+    } finally {
+      this.creating = false;
+    }
+  }
+
+  protected render() {
+    return html`
+      <div class="layout">
+        <form @submit=${(event: Event) => this.handleCreate(event)}>
+          <h3>Add product</h3>
+          <label>
+            <span>SKU</span>
+            <input name="sku" required placeholder="PAPER-A4-80" />
+          </label>
+          <label>
+            <span>Name</span>
+            <input name="name" required placeholder="A4 Copy Paper" />
+          </label>
+          <label>
+            <span>Description</span>
+            <textarea name="description" placeholder="Details visible in the catalog"></textarea>
+          </label>
+          <label>
+            <span>Unit price (cents)</span>
+            <input name="unitPriceCents" type="number" min="0" step="1" required />
+          </label>
+          <label>
+            <span>Stock quantity</span>
+            <input name="stockQty" type="number" min="0" step="1" required />
+          </label>
+          <button type="submit" ?disabled=${this.creating}>${this.creating ? 'Saving…' : 'Save product'}</button>
+        </form>
+        <div>
+          <table>
+            <thead>
+              <tr>
+                <th>SKU</th>
+                <th>Name</th>
+                <th>Price</th>
+                <th>Stock</th>
+                <th>Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${this.products.map(
+                product => html`<tr>
+                  <td>${product.sku}</td>
+                  <td>${product.name}</td>
+                  <td>${formatCurrency(product.unitPriceCents)}</td>
+                  <td>${product.stockQty}</td>
+                  <td>${formatDate(product.createdAt, undefined, { dateStyle: 'medium' })}</td>
+                </tr>`
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'products-page': ProductsPage;
+  }
+}

--- a/apps/web/src/pages/reports-page.ts
+++ b/apps/web/src/pages/reports-page.ts
@@ -1,0 +1,299 @@
+import { LitElement, css, html } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import Chart from 'chart.js/auto';
+import {
+  fetchDuesReport,
+  fetchSalesReport,
+  type DuesReport,
+  type SalesReport,
+  type SalesReportQuery
+} from '../api/client.js';
+import { formatCurrency } from '../utils/format.js';
+
+@customElement('reports-page')
+export class ReportsPage extends LitElement {
+  static styles = css`
+    :host {
+      display: grid;
+      gap: var(--space-xl);
+    }
+
+    form {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-sm);
+      align-items: flex-end;
+      background: var(--color-surface);
+      padding: var(--space-lg);
+      border-radius: var(--radius-lg);
+      border: 1px solid var(--color-border);
+      box-shadow: var(--shadow-sm);
+    }
+
+    label {
+      display: grid;
+      gap: var(--space-2xs);
+      font-size: 0.85rem;
+      color: var(--color-text-muted);
+    }
+
+    input,
+    select {
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--color-border);
+      padding: var(--space-sm) var(--space-md);
+      font-size: 0.95rem;
+    }
+
+    button {
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--color-primary);
+      background: var(--color-primary);
+      color: white;
+      padding: var(--space-sm) var(--space-lg);
+      font-size: 0.95rem;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: var(--space-xl);
+    }
+
+    canvas {
+      width: 100% !important;
+      height: 360px !important;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--color-surface);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      box-shadow: var(--shadow-sm);
+    }
+
+    th,
+    td {
+      padding: var(--space-md) var(--space-lg);
+      text-align: left;
+      border-bottom: 1px solid var(--color-border);
+      font-size: 0.9rem;
+    }
+
+    th {
+      text-transform: uppercase;
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      color: var(--color-text-muted);
+      background: rgba(37, 99, 235, 0.08);
+    }
+
+    tbody tr:last-child td {
+      border-bottom: none;
+    }
+  `;
+
+  @state()
+  private duesReport?: DuesReport;
+
+  @state()
+  private salesReport?: SalesReport;
+
+  @state()
+  private filters: SalesReportQuery = { groupBy: 'month' };
+
+  private salesChart?: Chart;
+  private duesChart?: Chart;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.refresh();
+  }
+
+  disconnectedCallback(): void {
+    this.salesChart?.destroy();
+    this.duesChart?.destroy();
+    super.disconnectedCallback();
+  }
+
+  private async refresh() {
+    try {
+      const [dues, sales] = await Promise.all([
+        fetchDuesReport(),
+        fetchSalesReport({
+          from: this.filters.from,
+          to: this.filters.to,
+          groupBy: this.filters.groupBy
+        })
+      ]);
+      this.duesReport = dues;
+      this.salesReport = sales;
+      await this.updateComplete;
+      this.renderCharts();
+    } catch (error) {
+      console.error('Failed to load reports', error);
+    }
+  }
+
+  protected updated(changed: Map<string, unknown>): void {
+    if (changed.has('duesReport') || changed.has('salesReport')) {
+      this.renderCharts();
+    }
+  }
+
+  private renderCharts() {
+    const salesCanvas = this.renderRoot.querySelector<HTMLCanvasElement>('#sales-report');
+    if (salesCanvas && this.salesReport) {
+      this.salesChart?.destroy();
+      this.salesChart = new Chart(salesCanvas, {
+        type: 'bar',
+        data: {
+          labels: this.salesReport.rows.map(row => row.period),
+          datasets: [
+            {
+              label: 'Sales',
+              data: this.salesReport.rows.map(row => row.totalCents / 100),
+              backgroundColor: '#2563eb'
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { display: false } },
+          scales: {
+            y: {
+              ticks: {
+                callback: value => `$${value}`
+              }
+            }
+          }
+        }
+      });
+    }
+
+    const duesCanvas = this.renderRoot.querySelector<HTMLCanvasElement>('#dues-report');
+    if (duesCanvas && this.duesReport) {
+      this.duesChart?.destroy();
+      const sorted = [...this.duesReport.customers].sort((a, b) => b.balanceCents - a.balanceCents);
+      this.duesChart = new Chart(duesCanvas, {
+        type: 'bar',
+        data: {
+          labels: sorted.map(item => item.customerName),
+          datasets: [
+            {
+              label: 'Outstanding balance',
+              data: sorted.map(item => item.balanceCents / 100),
+              backgroundColor: '#f97316'
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { display: false } },
+          scales: {
+            y: {
+              ticks: {
+                callback: value => `$${value}`
+              }
+            }
+          }
+        }
+      });
+    }
+  }
+
+  private async handleFilter(event: Event) {
+    event.preventDefault();
+    const form = event.target as HTMLFormElement;
+    const formData = new FormData(form);
+    this.filters = {
+      from: ((formData.get('from') as string) || undefined) as SalesReportQuery['from'],
+      to: ((formData.get('to') as string) || undefined) as SalesReportQuery['to'],
+      groupBy: (formData.get('groupBy') as SalesReportQuery['groupBy']) ?? 'month'
+    };
+    await this.refresh();
+  }
+
+  protected render() {
+    return html`
+      <form @submit=${(event: Event) => this.handleFilter(event)}>
+        <label>
+          <span>From</span>
+          <input type="date" name="from" .value=${this.filters.from ?? ''} />
+        </label>
+        <label>
+          <span>To</span>
+          <input type="date" name="to" .value=${this.filters.to ?? ''} />
+        </label>
+        <label>
+          <span>Group by</span>
+          <select name="groupBy" .value=${this.filters.groupBy}>
+            <option value="day">Day</option>
+            <option value="week">Week</option>
+            <option value="month">Month</option>
+          </select>
+        </label>
+        <button type="submit">Update</button>
+      </form>
+
+      <section class="grid">
+        <article>
+          <h3>Sales</h3>
+          <canvas id="sales-report"></canvas>
+          ${this.salesReport
+            ? html`<table>
+                <thead>
+                  <tr>
+                    <th>Period</th>
+                    <th>Invoices</th>
+                    <th>Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  ${this.salesReport.rows.map(
+                    row => html`<tr>
+                      <td>${row.period}</td>
+                      <td>${row.invoicesCount}</td>
+                      <td>${formatCurrency(row.totalCents)}</td>
+                    </tr>`
+                  )}
+                </tbody>
+              </table>`
+            : null}
+        </article>
+        <article>
+          <h3>Dues by customer</h3>
+          <canvas id="dues-report"></canvas>
+          ${this.duesReport
+            ? html`<table>
+                <thead>
+                  <tr>
+                    <th>Customer</th>
+                    <th>Invoiced</th>
+                    <th>Paid</th>
+                    <th>Balance</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  ${this.duesReport.customers.map(
+                    customer => html`<tr>
+                      <td>${customer.customerName}</td>
+                      <td>${formatCurrency(customer.invoicedCents)}</td>
+                      <td>${formatCurrency(customer.paidCents)}</td>
+                      <td>${formatCurrency(customer.balanceCents)}</td>
+                    </tr>`
+                  )}
+                </tbody>
+              </table>`
+            : null}
+        </article>
+      </section>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'reports-page': ReportsPage;
+  }
+}

--- a/apps/web/src/root-app.test.ts
+++ b/apps/web/src/root-app.test.ts
@@ -1,11 +1,13 @@
 import { fixture, html } from '@open-wc/testing';
 import { describe, expect, it } from 'vitest';
-import { exampleCustomer } from '@stationery/shared';
 import './root-app';
 
 describe('app-root', () => {
-  it('renders shared greeting', async () => {
+  it('renders app shell with navigation', async () => {
     const element = await fixture<HTMLElement>(html`<app-root></app-root>`);
-    expect(element.shadowRoot?.textContent).toContain(`Hello, ${exampleCustomer.name}!`);
+    const shell = element.shadowRoot?.querySelector('app-shell');
+    expect(shell).toBeTruthy();
+    const navItems = shell?.shadowRoot?.querySelectorAll('nav ul li');
+    expect(navItems?.length).toBeGreaterThan(0);
   });
 });

--- a/apps/web/src/root-app.ts
+++ b/apps/web/src/root-app.ts
@@ -1,52 +1,20 @@
 import { LitElement, css, html } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-import { exampleCustomer } from '@stationery/shared';
+import { customElement } from 'lit/decorators.js';
+import './app-shell.js';
 
 @customElement('app-root')
 export class AppRoot extends LitElement {
   static styles = css`
     :host {
-      display: flex;
-      align-items: center;
-      justify-content: center;
+      display: block;
       min-height: 100vh;
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background: linear-gradient(135deg, #d8eefe, #fef6e4);
-      color: #1f2933;
-      margin: 0;
-    }
-
-    main {
-      padding: 2rem 3rem;
-      border-radius: 1rem;
-      background: white;
-      box-shadow: 0 10px 40px rgba(15, 23, 42, 0.1);
-      text-align: center;
-      max-width: 480px;
-    }
-
-    h1 {
-      font-size: 2.25rem;
-      margin-bottom: 0.75rem;
-    }
-
-    p {
-      margin: 0.5rem 0 0;
-      font-size: 1.1rem;
+      background: var(--color-bg);
+      color: var(--color-text);
     }
   `;
 
-  @state()
-  private message = `Hello, ${exampleCustomer.name}!`;
-
   protected render() {
-    return html`
-      <main>
-        <h1>Stationery Web</h1>
-        <p>${this.message}</p>
-        <p>API proxy target: <code>/api</code></p>
-      </main>
-    `;
+    return html`<app-shell></app-shell>`;
   }
 }
 

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -1,0 +1,165 @@
+import { html, type TemplateResult } from 'lit';
+import { ReactiveController, ReactiveControllerHost } from 'lit';
+import './pages/dashboard-page.js';
+import './pages/customers-page.js';
+import './pages/products-page.js';
+import './pages/invoice-editor-page.js';
+import './pages/payments-page.js';
+import './pages/reports-page.js';
+
+export interface NavigationRoute {
+  path: string;
+  label: string;
+  icon: string;
+  description: string;
+  render: (url: URL) => TemplateResult;
+  match?: (url: URL) => boolean;
+  exact?: boolean;
+  includeInSidebar?: boolean;
+}
+
+export const navigationRoutes: NavigationRoute[] = [
+  {
+    path: '/',
+    label: 'Dashboard',
+    icon: '📊',
+    description: 'Overview of dues, invoices, and activity',
+    includeInSidebar: true,
+    exact: true,
+    render: () => html`<dashboard-page></dashboard-page>`
+  },
+  {
+    path: '/customers',
+    label: 'Customers',
+    icon: '👥',
+    description: 'Manage customers and quick actions',
+    includeInSidebar: true,
+    render: () => html`<customers-page></customers-page>`
+  },
+  {
+    path: '/products',
+    label: 'Products',
+    icon: '📦',
+    description: 'Browse and edit your catalog',
+    includeInSidebar: true,
+    render: () => html`<products-page></products-page>`
+  },
+  {
+    path: '/invoices/new',
+    label: 'New Invoice',
+    icon: '🧾',
+    description: 'Create and send invoices',
+    includeInSidebar: true,
+    render: url => html`<invoice-editor-page .prefillCustomerId=${Number(url.searchParams.get('customerId') ?? '')}></invoice-editor-page>`
+  },
+  {
+    path: '/payments',
+    label: 'Payments',
+    icon: '💸',
+    description: 'Record payments and update dues',
+    includeInSidebar: true,
+    render: url => {
+      const customerParam = url.searchParams.get('customer');
+      const parsed = customerParam ? Number(customerParam) : undefined;
+      const customerId = parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined;
+      return html`<payments-page .customer=${customerId}></payments-page>`;
+    }
+  },
+  {
+    path: '/reports',
+    label: 'Reports',
+    icon: '📈',
+    description: 'Dig into sales and dues trends',
+    includeInSidebar: true,
+    render: () => html`<reports-page></reports-page>`
+  },
+  {
+    path: '*',
+    label: 'Not found',
+    icon: '❓',
+    description: 'The requested page could not be found',
+    includeInSidebar: false,
+    match: () => true,
+    render: () => html`<section class="empty-state"><h2>Page not found</h2><p>Use the navigation to pick a section.</p></section>`
+  }
+];
+
+const resolveRoute = (path: string) => {
+  const url = new URL(path, window.location.origin);
+  return (
+    navigationRoutes.find(route =>
+      route.match ? route.match(url) : route.exact ? url.pathname === route.path : url.pathname.startsWith(route.path)
+    ) ?? navigationRoutes[navigationRoutes.length - 1]
+  );
+};
+
+export class AppRouter implements ReactiveController {
+  private host: ReactiveControllerHost;
+  private onChange?: (route: NavigationRoute, url: URL) => void;
+  private _path = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+  constructor(host: ReactiveControllerHost, onChange?: (route: NavigationRoute, url: URL) => void) {
+    this.host = host;
+    this.onChange = onChange;
+    host.addController(this);
+  }
+
+  hostConnected() {
+    window.addEventListener('popstate', this.handlePopstate);
+    this.notify();
+  }
+
+  hostDisconnected() {
+    window.removeEventListener('popstate', this.handlePopstate);
+  }
+
+  get currentPath() {
+    return this._path;
+  }
+
+  navigate(path: string, options: { replace?: boolean } = {}) {
+    const url = new URL(path, window.location.origin);
+    const fullPath = `${url.pathname}${url.search}${url.hash}`;
+    if (fullPath === this._path && !options.replace) {
+      this.notify();
+      return;
+    }
+
+    if (options.replace) {
+      window.history.replaceState({}, '', fullPath);
+    } else {
+      window.history.pushState({}, '', fullPath);
+    }
+
+    this._path = fullPath;
+    this.notify();
+  }
+
+  private handlePopstate = () => {
+    this._path = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    this.notify();
+  };
+
+  private notify() {
+    const url = new URL(this._path, window.location.origin);
+    const route = resolveRoute(this._path);
+    this.onChange?.(route, url);
+    this.host.requestUpdate();
+  }
+
+  render(): TemplateResult {
+    const url = new URL(this._path, window.location.origin);
+    const route = resolveRoute(this._path);
+    return route.render(url);
+  }
+}
+
+export const isRouteActive = (route: NavigationRoute, currentPath: string) => {
+  const url = new URL(currentPath, window.location.origin);
+  if (route.match && route.match(url)) return true;
+  if (route.exact) {
+    return url.pathname === route.path;
+  }
+  if (route.path === '*') return false;
+  return url.pathname === route.path || url.pathname.startsWith(`${route.path}/`);
+};

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -1,0 +1,72 @@
+:root {
+  --color-bg: #f5f7fb;
+  --color-surface: #ffffff;
+  --color-surface-strong: #f0f3fa;
+  --color-border: #d7deea;
+  --color-border-strong: #c0c8d8;
+  --color-text: #1f2933;
+  --color-text-subtle: #4b5563;
+  --color-text-muted: #6b7280;
+  --color-primary: #2563eb;
+  --color-primary-strong: #1d4ed8;
+  --color-accent: #f97316;
+  --color-positive: #16a34a;
+  --color-negative: #dc2626;
+  --color-focus: #9333ea;
+  --font-family-base: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+  --font-family-mono: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  --radius-xs: 0.25rem;
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.08);
+  --shadow-md: 0 10px 30px rgba(15, 23, 42, 0.08);
+  --shadow-lg: 0 18px 40px rgba(15, 23, 42, 0.12);
+  --space-2xs: 0.125rem;
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 0.75rem;
+  --space-lg: 1rem;
+  --space-xl: 1.5rem;
+  --space-2xl: 2rem;
+  --transition-snappy: 180ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+:root {
+  color-scheme: light;
+  font-family: var(--font-family-base);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--color-bg);
+}
+
+a {
+  color: inherit;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+:focus-visible {
+  outline: 3px solid var(--color-focus);
+  outline-offset: 2px;
+}

--- a/apps/web/src/utils/format.ts
+++ b/apps/web/src/utils/format.ts
@@ -1,0 +1,80 @@
+const currencyFormatterCache = new Map<string, Intl.NumberFormat>();
+
+const dateFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
+const getCurrencyFormatter = (currency: string, locale: string) => {
+  const key = `${locale}:${currency}`;
+  if (!currencyFormatterCache.has(key)) {
+    currencyFormatterCache.set(
+      key,
+      new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+      })
+    );
+  }
+  return currencyFormatterCache.get(key)!;
+};
+
+const getDateFormatter = (locale: string, options?: Intl.DateTimeFormatOptions) => {
+  const key = JSON.stringify({ locale, options });
+  if (!dateFormatterCache.has(key)) {
+    dateFormatterCache.set(key, new Intl.DateTimeFormat(locale, options));
+  }
+  return dateFormatterCache.get(key)!;
+};
+
+export const centsToNumber = (value: number | null | undefined) => {
+  if (value === null || value === undefined) return 0;
+  return value / 100;
+};
+
+export const numberToCents = (value: number | string | null | undefined) => {
+  if (value === null || value === undefined || value === '') return 0;
+  const parsed = typeof value === 'number' ? value : Number.parseFloat(value);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.round(parsed * 100);
+};
+
+export const formatCurrency = (valueCents: number, currency = 'USD', locale = 'en-US') =>
+  getCurrencyFormatter(currency, locale).format(centsToNumber(valueCents));
+
+export const formatDate = (value: string, locale = 'en-US', options?: Intl.DateTimeFormatOptions) => {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return getDateFormatter(locale, options).format(date);
+};
+
+export const formatRelativeDate = (value: string, locale = 'en-US') => {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const diffDays = Math.round(diff / (1000 * 60 * 60 * 24));
+  if (Math.abs(diffDays) > 14) {
+    return formatDate(value, locale, { dateStyle: 'medium' });
+  }
+  const formatter = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+  return formatter.format(-diffDays, 'day');
+};
+
+export const formatInvoiceStatus = (status: string) => {
+  switch (status) {
+    case 'draft':
+      return 'Draft';
+    case 'issued':
+      return 'Issued';
+    case 'partial':
+      return 'Partially Paid';
+    case 'paid':
+      return 'Paid';
+    case 'void':
+      return 'Voided';
+    default:
+      return status;
+  }
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,12 +114,21 @@ importers:
 
   apps/web:
     dependencies:
+      '@lit-labs/router':
+        specifier: 0.1.4
+        version: 0.1.4
       '@stationery/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      chart.js:
+        specifier: 4.4.3
+        version: 4.4.3
       lit:
         specifier: 3.1.2
         version: 3.1.2
+      motion:
+        specifier: 12.23.22
+        version: 12.23.22
     devDependencies:
       '@open-wc/testing':
         specifier: ^4.0.0
@@ -1177,6 +1186,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@kurkle/color@0.3.4':
+    resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
+
+  '@lit-labs/router@0.1.4':
+    resolution: {integrity: sha512-xURH6fOPE0MYfXa1nyl+qTIhZRVWkFa2oggTRodKAI2q/HjA2Va7HEKe7fMm8DdnFE+zEI2aUGnStawKpVh3lQ==}
+
   '@lit-labs/ssr-dom-shim@1.4.0':
     resolution: {integrity: sha512-ficsEARKnmmW5njugNYKipTm4SFnbik7CXtoencDZzmzo/dQ+2Q0bgkzJuoJP20Aj0F+izzJjOqsnkd6F/o1bw==}
 
@@ -1858,6 +1873,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chart.js@4.4.3:
+    resolution: {integrity: sha512-qK1gkGSRYcJzqrrzdR6a+I0vQ4/R+SoODXyAjscQ/4mzuNzySaMCd+hyVxitSY1+L2fjPD1Gbn+ibNqRmwQeLw==}
+    engines: {pnpm: '>=8'}
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
@@ -2575,6 +2594,20 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  framer-motion@12.23.22:
+    resolution: {integrity: sha512-ZgGvdxXCw55ZYvhoZChTlG6pUuehecgvEAJz0BHoC5pQKW1EC5xf1Mul1ej5+ai+pVY0pylyFfdl45qnM1/GsA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
@@ -3241,6 +3274,26 @@ packages:
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  motion-dom@12.23.21:
+    resolution: {integrity: sha512-5xDXx/AbhrfgsQmSE7YESMn4Dpo6x5/DTZ4Iyy4xqDvVHWvFVoV+V2Ri2S/ksx+D40wrZ7gPYiMWshkdoqNgNQ==}
+
+  motion-utils@12.23.6:
+    resolution: {integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==}
+
+  motion@12.23.22:
+    resolution: {integrity: sha512-iSq6X9vLHbeYwmHvhK//+U74ROaPnZmBuy60XZzqNl0QtZkWfoZyMDHYnpKuWFv0sNMqHgED8aCXk94LCoQPGg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -5267,6 +5320,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@kurkle/color@0.3.4': {}
+
+  '@lit-labs/router@0.1.4':
+    dependencies:
+      lit: 3.1.2
+
   '@lit-labs/ssr-dom-shim@1.4.0': {}
 
   '@lit/reactive-element@2.1.1':
@@ -6091,6 +6150,10 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chart.js@4.4.3:
+    dependencies:
+      '@kurkle/color': 0.3.4
 
   check-error@1.0.3:
     dependencies:
@@ -6972,6 +7035,12 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  framer-motion@12.23.22:
+    dependencies:
+      motion-dom: 12.23.21
+      motion-utils: 12.23.6
+      tslib: 2.8.1
+
   fresh@0.5.2: {}
 
   fs-constants@1.0.0: {}
@@ -7672,6 +7741,17 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.1
+
+  motion-dom@12.23.21:
+    dependencies:
+      motion-utils: 12.23.6
+
+  motion-utils@12.23.6: {}
+
+  motion@12.23.22:
+    dependencies:
+      framer-motion: 12.23.22
+      tslib: 2.8.1
 
   ms@2.0.0: {}
 


### PR DESCRIPTION
## Summary
- scaffold a reusable app shell with design tokens, responsive navigation, and custom router wiring the main sections
- implement dashboard, customer, product, invoice, payment, and reporting pages backed by a shared API client, Chart.js visuals, and Motion One micro animations
- add accessible, keyboard-friendly components such as customer list, product picker, invoice form, money input, and PDF preview to streamline the create → invoice → payment workflow

## Testing
- pnpm --filter @stationery/web test

------
https://chatgpt.com/codex/tasks/task_e_68e5568498dc832ea9c6fd5c4b7c436a