### PR TITLE
Enhance reporting exports and UI

### DIFF
--- a/apps/api/src/docs/openapi.ts
+++ b/apps/api/src/docs/openapi.ts
@@ -5,6 +5,7 @@ import {
   customerListQuerySchema,
   customerListResponseSchema,
   customerSchema,
+  duesReportQuerySchema,
   duesReportSchema,
   exampleCustomer,
   exampleCustomerCreate,
@@ -15,6 +16,7 @@ import {
   exampleInvoicePdfRequest,
   examplePayment,
   examplePaymentCreate,
+  examplePaymentsLedger,
   exampleProduct,
   exampleProductCreate,
   exampleSalesReport,
@@ -33,6 +35,8 @@ import {
   productListQuerySchema,
   productListResponseSchema,
   productSchema,
+  paymentsLedgerQuerySchema,
+  paymentsLedgerSchema,
   salesReportQuerySchema,
   salesReportSchema
 } from '@stationery/shared';
@@ -66,6 +70,7 @@ registry.register('PaymentCreate', paymentCreateSchema);
 registry.register('PaymentListResponse', paymentListResponseSchema);
 registry.register('DuesReport', duesReportSchema);
 registry.register('SalesReport', salesReportSchema);
+registry.register('PaymentsLedger', paymentsLedgerSchema);
 
 registry.registerPath({
   method: 'get',
@@ -410,6 +415,7 @@ registry.registerPath({
   method: 'get',
   path: '/api/v1/reports/dues',
   description: 'Outstanding balances per customer',
+  request: { query: duesReportQuerySchema },
   responses: {
     200: {
       description: 'Dues report',
@@ -427,6 +433,19 @@ registry.registerPath({
     200: {
       description: 'Sales report',
       content: { 'application/json': { schema: salesReportSchema, example: exampleSalesReport } }
+    }
+  }
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/reports/payments',
+  description: 'Payments ledger with running totals',
+  request: { query: paymentsLedgerQuerySchema },
+  responses: {
+    200: {
+      description: 'Payments ledger',
+      content: { 'application/json': { schema: paymentsLedgerSchema, example: examplePaymentsLedger } }
     }
   }
 });

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,82 +1,128 @@
 import { Router } from 'express';
-import type { SQL } from 'drizzle-orm';
-import { and, inArray, sql } from 'drizzle-orm';
+import { type DuesReportQuery, type PaymentsLedgerQuery, type SalesReportQuery } from '@stationery/shared';
 import {
-  customerLedgerSchema,
-  duesReportSchema,
-  salesReportQuerySchema,
-  salesReportSchema
-} from '@stationery/shared';
-import { db, customerLedgerView, invoices } from '../db/client.js';
+  getDuesReport,
+  getPaymentsLedger,
+  getSalesReport
+} from '../services/report-data.js';
+import {
+  renderDuesReportPdf,
+  renderPaymentsLedgerPdf,
+  renderSalesReportPdf
+} from '../services/report-pdf.js';
 import { asyncHandler } from '../utils/async-handler.js';
+import { streamCsv } from '../utils/csv.js';
+import { sendPdfBuffer } from '../utils/pdf.js';
 
 const router = Router();
 
 router.get(
   '/dues',
   asyncHandler((_req, res) => {
-    const ledgerRows = db.select().from(customerLedgerView).all();
-    const payload = duesReportSchema.parse({
-      generatedAt: new Date().toISOString(),
-      customers: ledgerRows.map(row => customerLedgerSchema.parse(row))
-    });
-
-    res.json(payload);
+    const report = getDuesReport(_req.query as DuesReportQuery);
+    res.json(report);
   })
 );
 
-const groupFormats = {
-  day: '%Y-%m-%d',
-  week: '%Y-%W',
-  month: '%Y-%m'
-} as const;
+router.get(
+  '/dues.csv',
+  asyncHandler((req, res) => {
+    const report = getDuesReport(req.query as DuesReportQuery);
+    streamCsv(res, {
+      filename: `dues-report-${new Date().toISOString().slice(0, 10)}.csv`,
+      header: ['Customer', 'Invoiced', 'Paid', 'Balance'],
+      rows: report.customers.map(customer => [
+        customer.customerName,
+        (customer.invoicedCents / 100).toFixed(2),
+        (customer.paidCents / 100).toFixed(2),
+        (customer.balanceCents / 100).toFixed(2)
+      ])
+    });
+  })
+);
+
+router.get(
+  '/dues.pdf',
+  asyncHandler(async (req, res) => {
+    const report = getDuesReport(req.query as DuesReportQuery);
+    const buffer = await renderDuesReportPdf(report);
+    sendPdfBuffer(res, buffer, {
+      filename: `dues-report-${new Date().toISOString().slice(0, 10)}.pdf`
+    });
+  })
+);
 
 router.get(
   '/sales',
   asyncHandler((req, res) => {
-    const query = salesReportQuerySchema.parse(req.query);
+    const report = getSalesReport(req.query as SalesReportQuery);
+    res.json(report);
+  })
+);
 
-    const filters: SQL[] = [inArray(invoices.status, ['issued', 'partial', 'paid'])];
-
-    if (query.from) {
-      filters.push(sql`datetime(${invoices.issueDate}) >= datetime(${query.from} || ' 00:00:00')`);
-    }
-
-    if (query.to) {
-      filters.push(sql`datetime(${invoices.issueDate}) <= datetime(${query.to} || ' 23:59:59')`);
-    }
-
-    const whereClause: SQL | undefined =
-      filters.length === 0
-        ? undefined
-        : filters.length === 1
-          ? filters[0]
-          : and(...(filters as [SQL, SQL, ...SQL[]]));
-
-    const strftimeFormat = groupFormats[query.groupBy];
-
-    const rows = db
-      .select({
-        period: sql<string>`strftime(${strftimeFormat}, ${invoices.issueDate})`,
-        invoicesCount: sql<number>`count(*)`,
-        totalCents: sql<number>`sum(${invoices.grandTotalCents})`
-      })
-      .from(invoices)
-      .where(whereClause)
-      .groupBy(sql`strftime(${strftimeFormat}, ${invoices.issueDate})`)
-      .orderBy(sql`strftime(${strftimeFormat}, ${invoices.issueDate})`)
-      .all();
-
-    const payload = salesReportSchema.parse({
-      generatedAt: new Date().toISOString(),
-      rows: rows.map(row => ({
-        period: row.period,
-        invoicesCount: row.invoicesCount ?? 0,
-        totalCents: row.totalCents ?? 0
-      }))
+router.get(
+  '/sales.csv',
+  asyncHandler((req, res) => {
+    const report = getSalesReport(req.query as SalesReportQuery);
+    streamCsv(res, {
+      filename: `sales-report-${new Date().toISOString().slice(0, 10)}.csv`,
+      header: ['Period', 'Invoices', 'Total'],
+      rows: report.rows.map(row => [
+        row.period,
+        row.invoicesCount,
+        (row.totalCents / 100).toFixed(2)
+      ])
     });
+  })
+);
 
-    res.json(payload);
+router.get(
+  '/sales.pdf',
+  asyncHandler(async (req, res) => {
+    const report = getSalesReport(req.query as SalesReportQuery);
+    const buffer = await renderSalesReportPdf(report);
+    sendPdfBuffer(res, buffer, {
+      filename: `sales-report-${new Date().toISOString().slice(0, 10)}.pdf`
+    });
+  })
+);
+
+router.get(
+  '/payments',
+  asyncHandler((req, res) => {
+    const ledger = getPaymentsLedger(req.query as PaymentsLedgerQuery);
+    res.json(ledger);
+  })
+);
+
+router.get(
+  '/payments.csv',
+  asyncHandler((req, res) => {
+    const ledger = getPaymentsLedger(req.query as PaymentsLedgerQuery);
+    streamCsv(res, {
+      filename: `payments-ledger-${new Date().toISOString().slice(0, 10)}.csv`,
+      header: ['Paid At', 'Customer', 'Invoice', 'Method', 'Amount', 'Running Total', 'Note'],
+      rows: ledger.entries.map(entry => [
+        entry.paidAt,
+        entry.customerName,
+        entry.invoiceNo ?? '',
+        entry.method,
+        (entry.amountCents / 100).toFixed(2),
+        (entry.runningBalanceCents / 100).toFixed(2),
+        entry.note ?? ''
+      ])
+    });
+  })
+);
+
+router.get(
+  '/payments.pdf',
+  asyncHandler(async (req, res) => {
+    const ledger = getPaymentsLedger(req.query as PaymentsLedgerQuery);
+    const buffer = await renderPaymentsLedgerPdf(ledger);
+    sendPdfBuffer(res, buffer, {
+      filename: `payments-ledger-${new Date().toISOString().slice(0, 10)}.pdf`
+    });
   })
 );
 

--- a/apps/api/src/services/report-data.ts
+++ b/apps/api/src/services/report-data.ts
@@ -1,0 +1,246 @@
+import type { SQL } from 'drizzle-orm';
+import { and, desc, eq, sql } from 'drizzle-orm';
+import {
+  customerLedgerSchema,
+  duesReportSchema,
+  duesReportQuerySchema,
+  paymentsLedgerEntrySchema,
+  paymentsLedgerQuerySchema,
+  paymentsLedgerSchema,
+  salesReportQuerySchema,
+  salesReportSchema,
+  type DuesReport,
+  type DuesReportQuery,
+  type PaymentsLedger,
+  type PaymentsLedgerQuery,
+  type SalesReport,
+  type SalesReportQuery
+} from '@stationery/shared';
+import {
+  customerLedgerView,
+  customers,
+  db,
+  invoices,
+  payments
+} from '../db/client.js';
+import { toIsoDateTime } from '../utils/datetime.js';
+
+function buildWhereClause(filters: SQL[]) {
+  if (filters.length === 0) return undefined;
+  if (filters.length === 1) return filters[0];
+  return and(...(filters as [SQL, SQL, ...SQL[]]));
+}
+
+export function getDuesReport(query: DuesReportQuery = {}): DuesReport {
+  const parsed = duesReportQuerySchema.parse(query);
+
+  const filters: SQL[] = [];
+
+  if (parsed.customerId) {
+    filters.push(eq(customerLedgerView.customerId, parsed.customerId));
+  }
+
+  if (parsed.minBalanceCents !== undefined) {
+    filters.push(sql`${customerLedgerView.balanceCents} >= ${parsed.minBalanceCents}`);
+  }
+
+  if (parsed.search) {
+    const like = `%${parsed.search.toLowerCase()}%`;
+    filters.push(sql`lower(${customerLedgerView.customerName}) LIKE ${like}`);
+  }
+
+  const whereClause = buildWhereClause(filters);
+
+  let selection = db.select().from(customerLedgerView);
+  if (whereClause) {
+    selection = selection.where(whereClause);
+  }
+
+  const rows = selection.orderBy(desc(customerLedgerView.balanceCents)).all();
+  const customersData = rows.map(row => customerLedgerSchema.parse(row));
+
+  const summary = customersData.reduce(
+    (acc, item) => {
+      acc.totalInvoicedCents += item.invoicedCents;
+      acc.totalPaidCents += item.paidCents;
+      acc.totalBalanceCents += item.balanceCents;
+      return acc;
+    },
+    { totalInvoicedCents: 0, totalPaidCents: 0, totalBalanceCents: 0 }
+  );
+
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    customers: customersData,
+    summary: {
+      customersCount: customersData.length,
+      ...summary
+    }
+  } satisfies DuesReport;
+
+  return duesReportSchema.parse(payload);
+}
+
+export function getSalesReport(query: SalesReportQuery = {}): SalesReport {
+  const parsed = salesReportQuerySchema.parse(query);
+
+  const filters: SQL[] = [inArrayIssuedStatuses()];
+
+  if (parsed.from) {
+    filters.push(sql`datetime(${invoices.issueDate}) >= datetime(${parsed.from} || ' 00:00:00')`);
+  }
+
+  if (parsed.to) {
+    filters.push(sql`datetime(${invoices.issueDate}) <= datetime(${parsed.to} || ' 23:59:59')`);
+  }
+
+  const whereClause = buildWhereClause(filters);
+
+  const strftimeFormat = groupFormats[parsed.groupBy];
+
+  let selection = db
+    .select({
+      period: sql<string>`strftime(${strftimeFormat}, ${invoices.issueDate})`,
+      invoicesCount: sql<number>`count(*)`,
+      totalCents: sql<number>`sum(${invoices.grandTotalCents})`
+    })
+    .from(invoices)
+    .groupBy(sql`strftime(${strftimeFormat}, ${invoices.issueDate})`)
+    .orderBy(sql`strftime(${strftimeFormat}, ${invoices.issueDate})`);
+
+  if (whereClause) {
+    selection = selection.where(whereClause);
+  }
+
+  const rows = selection.all();
+
+  const parsedRows = rows.map(row => ({
+    period: row.period,
+    invoicesCount: row.invoicesCount ?? 0,
+    totalCents: row.totalCents ?? 0
+  }));
+
+  const summary = parsedRows.reduce(
+    (acc, item) => {
+      acc.totalInvoicesCount += item.invoicesCount;
+      acc.totalCents += item.totalCents;
+      return acc;
+    },
+    { totalInvoicesCount: 0, totalCents: 0 }
+  );
+
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    rows: parsedRows,
+    summary
+  } satisfies SalesReport;
+
+  return salesReportSchema.parse(payload);
+}
+
+const groupFormats = {
+  day: '%Y-%m-%d',
+  week: '%Y-%W',
+  month: '%Y-%m'
+} as const;
+
+function inArrayIssuedStatuses(): SQL {
+  return sql`${invoices.status} IN ('issued', 'partial', 'paid')`;
+}
+
+export function getPaymentsLedger(query: PaymentsLedgerQuery = {}): PaymentsLedger {
+  const parsed = paymentsLedgerQuerySchema.parse(query);
+
+  const filters: SQL[] = [];
+
+  if (parsed.customerId) {
+    filters.push(eq(payments.customerId, parsed.customerId));
+  }
+
+  if (parsed.invoiceId) {
+    filters.push(eq(payments.invoiceId, parsed.invoiceId));
+  }
+
+  if (parsed.from) {
+    filters.push(sql`datetime(${payments.paidAt}) >= datetime(${parsed.from} || ' 00:00:00')`);
+  }
+
+  if (parsed.to) {
+    filters.push(sql`datetime(${payments.paidAt}) <= datetime(${parsed.to} || ' 23:59:59')`);
+  }
+
+  const whereClause = buildWhereClause(filters);
+
+  let selection = db
+    .select({
+      id: payments.id,
+      customerId: payments.customerId,
+      invoiceId: payments.invoiceId,
+      amountCents: payments.amountCents,
+      method: payments.method,
+      paidAt: payments.paidAt,
+      note: payments.note,
+      customerName: customers.name,
+      invoiceNo: invoices.invoiceNo
+    })
+    .from(payments)
+    .leftJoin(customers, eq(customers.id, payments.customerId))
+    .leftJoin(invoices, eq(invoices.id, payments.invoiceId));
+
+  if (whereClause) {
+    selection = selection.where(whereClause);
+  }
+
+  selection =
+    parsed.direction === 'asc'
+      ? selection.orderBy(payments.paidAt, payments.id)
+      : selection.orderBy(desc(payments.paidAt), desc(payments.id));
+
+  const rows = selection.all();
+
+  const chronological = [...rows].sort((a, b) => new Date(a.paidAt).getTime() - new Date(b.paidAt).getTime());
+  let runningTotal = 0;
+  const runningMap = new Map<number, number>();
+  chronological.forEach(row => {
+    runningTotal += row.amountCents ?? 0;
+    runningMap.set(row.id, runningTotal);
+  });
+
+  const entries = rows.map(row =>
+    paymentsLedgerEntrySchema.parse({
+      ...row,
+      customerName: row.customerName ?? 'Unknown customer',
+      invoiceNo: row.invoiceNo ?? null,
+      note: row.note ?? null,
+      paidAt: toIsoDateTime(row.paidAt),
+      runningBalanceCents: runningMap.get(row.id) ?? row.amountCents ?? 0
+    })
+  );
+
+  const summary = entries.reduce(
+    (acc, entry) => {
+      acc.totalPaidCents += entry.amountCents;
+      if (!acc.firstPaymentAt || entry.paidAt < acc.firstPaymentAt) {
+        acc.firstPaymentAt = entry.paidAt;
+      }
+      if (!acc.lastPaymentAt || entry.paidAt > acc.lastPaymentAt) {
+        acc.lastPaymentAt = entry.paidAt;
+      }
+      return acc;
+    },
+    { totalPaidCents: 0, firstPaymentAt: null as string | null, lastPaymentAt: null as string | null }
+  );
+
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    entries,
+    summary: {
+      entriesCount: entries.length,
+      totalPaidCents: summary.totalPaidCents,
+      firstPaymentAt: summary.firstPaymentAt,
+      lastPaymentAt: summary.lastPaymentAt
+    }
+  } satisfies PaymentsLedger;
+
+  return paymentsLedgerSchema.parse(payload);
+}

--- a/apps/api/src/services/report-pdf.ts
+++ b/apps/api/src/services/report-pdf.ts
@@ -1,0 +1,116 @@
+import puppeteer, { Browser, LaunchOptions } from 'puppeteer';
+import {
+  type DuesReport,
+  type PaymentsLedger,
+  type SalesReport
+} from '@stationery/shared';
+import {
+  renderDuesReportHtml,
+  renderPaymentsLedgerHtml,
+  renderSalesReportHtml
+} from '../templates/reports/render.js';
+
+interface ReportPdfRenderer {
+  render(html: string): Promise<Buffer>;
+  close(): Promise<void>;
+}
+
+class PuppeteerReportPdfRenderer implements ReportPdfRenderer {
+  private browserPromise: Promise<Browser> | null = null;
+
+  constructor(private readonly launchOptions: LaunchOptions = {}) {}
+
+  private async getBrowser() {
+    if (!this.browserPromise) {
+      const headless = (process.env.PUPPETEER_HEADLESS as LaunchOptions['headless']) ?? 'new';
+      const executablePath = process.env.PUPPETEER_EXECUTABLE_PATH;
+
+      this.browserPromise = puppeteer
+        .launch({
+          headless,
+          executablePath: executablePath && executablePath.length > 0 ? executablePath : undefined,
+          args: ['--no-sandbox', '--font-render-hinting=medium', '--disable-dev-shm-usage'],
+          ...this.launchOptions
+        })
+        .catch(error => {
+          this.browserPromise = null;
+          throw error;
+        });
+    }
+
+    return this.browserPromise;
+  }
+
+  async render(html: string) {
+    const browser = await this.getBrowser();
+    const page = await browser.newPage();
+    try {
+      await page.setContent(html, { waitUntil: 'networkidle0' });
+      await page.emulateMediaType('print');
+
+      const pdfBuffer = await page.pdf({
+        format: 'A4',
+        printBackground: true,
+        preferCSSPageSize: true,
+        margin: { top: '18mm', bottom: '20mm', left: '18mm', right: '18mm' }
+      });
+
+      return Buffer.from(pdfBuffer);
+    } finally {
+      await page.close();
+    }
+  }
+
+  async close() {
+    if (this.browserPromise) {
+      const browser = await this.browserPromise;
+      await browser.close();
+      this.browserPromise = null;
+    }
+  }
+}
+
+class MockReportPdfRenderer implements ReportPdfRenderer {
+  async render(html: string) {
+    const payload = `%PDF-1.4\n%mock\n${Buffer.from(html).toString('base64')}`;
+    return Buffer.from(payload);
+  }
+
+  async close() {
+    return Promise.resolve();
+  }
+}
+
+let activeRenderer: ReportPdfRenderer | null = null;
+
+function getRenderer(): ReportPdfRenderer {
+  if (activeRenderer) return activeRenderer;
+  if (process.env.MOCK_REPORT_PDF === 'true' || process.env.NODE_ENV === 'test') {
+    activeRenderer = new MockReportPdfRenderer();
+  } else {
+    activeRenderer = new PuppeteerReportPdfRenderer();
+  }
+  return activeRenderer;
+}
+
+export function setReportPdfRenderer(renderer: ReportPdfRenderer | null) {
+  activeRenderer = renderer;
+}
+
+export async function renderDuesReportPdf(report: DuesReport) {
+  return getRenderer().render(renderDuesReportHtml(report));
+}
+
+export async function renderSalesReportPdf(report: SalesReport) {
+  return getRenderer().render(renderSalesReportHtml(report));
+}
+
+export async function renderPaymentsLedgerPdf(ledger: PaymentsLedger) {
+  return getRenderer().render(renderPaymentsLedgerHtml(ledger));
+}
+
+process.once('exit', async () => {
+  if (activeRenderer) {
+    await activeRenderer.close().catch(() => {});
+  }
+});

--- a/apps/api/src/templates/reports/render.ts
+++ b/apps/api/src/templates/reports/render.ts
@@ -1,0 +1,232 @@
+import {
+  type DuesReport,
+  type PaymentsLedger,
+  type SalesReport
+} from '@stationery/shared';
+
+const currency = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD'
+});
+
+const formatCurrency = (cents: number) => currency.format(cents / 100);
+
+const baseStyles = `
+  body {
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    padding: 24px;
+    color: #1f2933;
+  }
+  h1 {
+    font-size: 24px;
+    margin-bottom: 8px;
+  }
+  h2 {
+    font-size: 18px;
+    margin: 24px 0 12px;
+  }
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 12px;
+  }
+  th,
+  td {
+    border: 1px solid #d0d7de;
+    padding: 8px;
+    text-align: left;
+  }
+  th {
+    background: #f1f5f9;
+    text-transform: uppercase;
+    font-size: 11px;
+    letter-spacing: 0.05em;
+  }
+  tfoot td {
+    font-weight: 600;
+  }
+  .meta {
+    color: #52606d;
+    font-size: 12px;
+    margin-bottom: 16px;
+  }
+  .summary {
+    display: flex;
+    gap: 24px;
+    margin: 16px 0 32px;
+  }
+  .summary-item {
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    padding: 12px 16px;
+    border-radius: 8px;
+    min-width: 160px;
+  }
+  .summary-item span {
+    display: block;
+    font-size: 11px;
+    text-transform: uppercase;
+    color: #64748b;
+    margin-bottom: 4px;
+  }
+  .summary-item strong {
+    font-size: 14px;
+  }
+`;
+
+const htmlShell = (title: string, body: string) => `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>${title}</title>
+    <style>${baseStyles}</style>
+  </head>
+  <body>
+    ${body}
+  </body>
+</html>`;
+
+export function renderDuesReportHtml(report: DuesReport) {
+  const body = `
+    <h1>Dues by Customer</h1>
+    <p class="meta">Generated ${new Date(report.generatedAt).toLocaleString()}</p>
+    <div class="summary">
+      <div class="summary-item">
+        <span>Customers</span>
+        <strong>${report.summary.customersCount}</strong>
+      </div>
+      <div class="summary-item">
+        <span>Total Invoiced</span>
+        <strong>${formatCurrency(report.summary.totalInvoicedCents)}</strong>
+      </div>
+      <div class="summary-item">
+        <span>Total Paid</span>
+        <strong>${formatCurrency(report.summary.totalPaidCents)}</strong>
+      </div>
+      <div class="summary-item">
+        <span>Outstanding</span>
+        <strong>${formatCurrency(report.summary.totalBalanceCents)}</strong>
+      </div>
+    </div>
+    <table>
+      <thead>
+        <tr>
+          <th>Customer</th>
+          <th>Invoiced</th>
+          <th>Paid</th>
+          <th>Balance</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${report.customers
+          .map(
+            customer => `
+              <tr>
+                <td>${customer.customerName}</td>
+                <td>${formatCurrency(customer.invoicedCents)}</td>
+                <td>${formatCurrency(customer.paidCents)}</td>
+                <td>${formatCurrency(customer.balanceCents)}</td>
+              </tr>
+            `
+          )
+          .join('')}
+      </tbody>
+    </table>
+  `;
+
+  return htmlShell('Dues report', body);
+}
+
+export function renderSalesReportHtml(report: SalesReport) {
+  const body = `
+    <h1>Sales Summary</h1>
+    <p class="meta">Generated ${new Date(report.generatedAt).toLocaleString()}</p>
+    <div class="summary">
+      <div class="summary-item">
+        <span>Invoices</span>
+        <strong>${report.summary.totalInvoicesCount}</strong>
+      </div>
+      <div class="summary-item">
+        <span>Total Sales</span>
+        <strong>${formatCurrency(report.summary.totalCents)}</strong>
+      </div>
+    </div>
+    <table>
+      <thead>
+        <tr>
+          <th>Period</th>
+          <th>Invoices</th>
+          <th>Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${report.rows
+          .map(
+            row => `
+              <tr>
+                <td>${row.period}</td>
+                <td>${row.invoicesCount}</td>
+                <td>${formatCurrency(row.totalCents)}</td>
+              </tr>
+            `
+          )
+          .join('')}
+      </tbody>
+    </table>
+  `;
+
+  return htmlShell('Sales report', body);
+}
+
+export function renderPaymentsLedgerHtml(ledger: PaymentsLedger) {
+  const body = `
+    <h1>Payments Ledger</h1>
+    <p class="meta">Generated ${new Date(ledger.generatedAt).toLocaleString()}</p>
+    <div class="summary">
+      <div class="summary-item">
+        <span>Entries</span>
+        <strong>${ledger.summary.entriesCount}</strong>
+      </div>
+      <div class="summary-item">
+        <span>Total Received</span>
+        <strong>${formatCurrency(ledger.summary.totalPaidCents)}</strong>
+      </div>
+      <div class="summary-item">
+        <span>Period</span>
+        <strong>${ledger.summary.firstPaymentAt ? `${new Date(ledger.summary.firstPaymentAt).toLocaleDateString()} - ${new Date(ledger.summary.lastPaymentAt ?? ledger.summary.firstPaymentAt).toLocaleDateString()}` : 'n/a'}</strong>
+      </div>
+    </div>
+    <table>
+      <thead>
+        <tr>
+          <th>Paid At</th>
+          <th>Customer</th>
+          <th>Invoice</th>
+          <th>Method</th>
+          <th>Amount</th>
+          <th>Running Total</th>
+          <th>Note</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${ledger.entries
+          .map(
+            entry => `
+              <tr>
+                <td>${new Date(entry.paidAt).toLocaleString()}</td>
+                <td>${entry.customerName}</td>
+                <td>${entry.invoiceNo ?? ''}</td>
+                <td>${entry.method}</td>
+                <td>${formatCurrency(entry.amountCents)}</td>
+                <td>${formatCurrency(entry.runningBalanceCents)}</td>
+                <td>${entry.note ?? ''}</td>
+              </tr>
+            `
+          )
+          .join('')}
+      </tbody>
+    </table>
+  `;
+
+  return htmlShell('Payments ledger', body);
+}

--- a/apps/api/src/utils/csv.ts
+++ b/apps/api/src/utils/csv.ts
@@ -1,0 +1,34 @@
+import { Readable } from 'node:stream';
+import type { Response } from 'express';
+
+export interface CsvStreamOptions {
+  filename: string;
+  header: string[];
+  rows: (string | number | null | undefined)[][];
+}
+
+const UTF8_BOM = '\ufeff';
+
+function escapeValue(value: string | number | null | undefined) {
+  if (value === null || value === undefined) return '';
+  const stringValue = String(value);
+  if (stringValue.includes('"')) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+  if (/[\n,]/u.test(stringValue)) {
+    return `"${stringValue}"`;
+  }
+  return stringValue;
+}
+
+function formatRow(values: (string | number | null | undefined)[]) {
+  return values.map(escapeValue).join(',') + '\r\n';
+}
+
+export function streamCsv(res: Response, options: CsvStreamOptions) {
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="${options.filename}"`);
+
+  const lines = [UTF8_BOM + formatRow(options.header), ...options.rows.map(formatRow)];
+  Readable.from(lines).pipe(res);
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,7 +11,6 @@
     "format": "prettier --write \"src/**/*.ts\""
   },
   "dependencies": {
-    "decimal.js": "^10.4.3",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -11,6 +11,7 @@ import {
   exampleInvoicePdfRequest,
   examplePayment,
   examplePaymentCreate,
+  examplePaymentsLedger,
   exampleProduct,
   exampleProductCreate,
   exampleSalesReport,
@@ -23,6 +24,8 @@ import {
   paymentSchema,
   productCreateSchema,
   productSchema,
+  paymentsLedgerQuerySchema,
+  paymentsLedgerSchema,
   salesReportQuerySchema,
   salesReportSchema
 } from './index.js';
@@ -61,10 +64,16 @@ describe('shared schemas', () => {
     expect(() => healthCheckSchema.parse(healthCheckExample)).not.toThrow();
     expect(() => duesReportSchema.parse(exampleDuesReport)).not.toThrow();
     expect(() => salesReportSchema.parse(exampleSalesReport)).not.toThrow();
+    expect(() => paymentsLedgerSchema.parse(examplePaymentsLedger)).not.toThrow();
   });
 
   it('applies default grouping in sales report query', () => {
     const result = salesReportQuerySchema.parse({});
     expect(result.groupBy).toBe('month');
+  });
+
+  it('defaults ledger direction to descending', () => {
+    const query = paymentsLedgerQuerySchema.parse({});
+    expect(query.direction).toBe('desc');
   });
 });

--- a/packages/shared/src/reports.ts
+++ b/packages/shared/src/reports.ts
@@ -1,17 +1,41 @@
 import { z } from 'zod';
 import { dateOnlyStringSchema, moneyCentsSchema } from './common.js';
 import { customerLedgerSchema, exampleCustomerLedger } from './customers.js';
+import { paymentSchema } from './payments.js';
+
+export const duesReportQuerySchema = z.object({
+  customerId: z.number().int().positive().optional(),
+  minBalanceCents: moneyCentsSchema.optional(),
+  search: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+});
 
 export const duesReportSchema = z.object({
   customers: z.array(customerLedgerSchema),
-  generatedAt: z.string()
+  generatedAt: z.string(),
+  summary: z.object({
+    customersCount: z.number().int().min(0),
+    totalInvoicedCents: moneyCentsSchema,
+    totalPaidCents: moneyCentsSchema,
+    totalBalanceCents: moneyCentsSchema
+  })
 });
 
 export type DuesReport = z.infer<typeof duesReportSchema>;
+export type DuesReportQuery = z.infer<typeof duesReportQuerySchema>;
 
 export const exampleDuesReport: DuesReport = {
   generatedAt: '2024-01-07T00:00:00.000Z',
-  customers: [exampleCustomerLedger]
+  customers: [exampleCustomerLedger],
+  summary: {
+    customersCount: 1,
+    totalInvoicedCents: exampleCustomerLedger.invoicedCents,
+    totalPaidCents: exampleCustomerLedger.paidCents,
+    totalBalanceCents: exampleCustomerLedger.balanceCents
+  }
 };
 
 export const salesReportQuerySchema = z.object({
@@ -28,7 +52,11 @@ export const salesReportRowSchema = z.object({
 
 export const salesReportSchema = z.object({
   rows: z.array(salesReportRowSchema),
-  generatedAt: z.string()
+  generatedAt: z.string(),
+  summary: z.object({
+    totalInvoicesCount: z.number().int().min(0),
+    totalCents: moneyCentsSchema
+  })
 });
 
 export type SalesReportQuery = z.infer<typeof salesReportQuerySchema>;
@@ -43,5 +71,65 @@ export const exampleSalesReport: SalesReport = {
       invoicesCount: 3,
       totalCents: 42000
     }
-  ]
+  ],
+  summary: {
+    totalInvoicesCount: 3,
+    totalCents: 42000
+  }
+};
+
+export const paymentsLedgerQuerySchema = z.object({
+  from: dateOnlyStringSchema.optional(),
+  to: dateOnlyStringSchema.optional(),
+  customerId: z.number().int().positive().optional(),
+  invoiceId: z.number().int().positive().optional(),
+  direction: z.enum(['asc', 'desc']).default('desc')
+});
+
+export const paymentsLedgerEntrySchema = paymentSchema
+  .omit({ note: true })
+  .extend({
+    note: z.string().trim().max(240).nullish(),
+    customerName: z.string(),
+    invoiceNo: z.string().nullish(),
+    runningBalanceCents: moneyCentsSchema
+  });
+
+export const paymentsLedgerSchema = z.object({
+  entries: z.array(paymentsLedgerEntrySchema),
+  generatedAt: z.string(),
+  summary: z.object({
+    entriesCount: z.number().int().min(0),
+    totalPaidCents: moneyCentsSchema,
+    firstPaymentAt: z.string().nullable(),
+    lastPaymentAt: z.string().nullable()
+  })
+});
+
+export type PaymentsLedgerQuery = z.infer<typeof paymentsLedgerQuerySchema>;
+export type PaymentsLedgerEntry = z.infer<typeof paymentsLedgerEntrySchema>;
+export type PaymentsLedger = z.infer<typeof paymentsLedgerSchema>;
+
+export const examplePaymentsLedger: PaymentsLedger = {
+  generatedAt: '2024-01-07T00:00:00.000Z',
+  entries: [
+    {
+      id: 1,
+      customerId: 10,
+      customerName: 'Acme Office Supplies',
+      invoiceId: 22,
+      invoiceNo: 'INV-00022',
+      amountCents: 21500,
+      method: 'card',
+      paidAt: '2024-01-02T15:22:00.000Z',
+      note: null,
+      runningBalanceCents: 21500
+    }
+  ],
+  summary: {
+    entriesCount: 1,
+    totalPaidCents: 21500,
+    firstPaymentAt: '2024-01-02T15:22:00.000Z',
+    lastPaymentAt: '2024-01-02T15:22:00.000Z'
+  }
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,9 +160,6 @@ importers:
 
   packages/shared:
     dependencies:
-      decimal.js:
-        specifier: ^10.4.3
-        version: 10.6.0
       zod:
         specifier: ^3.23.8
         version: 3.23.8


### PR DESCRIPTION
## Summary
- add dedicated report services for dues, sales, and payments with CSV/PDF exports and API docs updates
- expand shared schemas and utilities to support report summaries, ledger data, and deterministic rounding without decimal.js
- refresh the reports page with filters, download actions, charts, and cross-check summaries tied to the new API client helpers

## Testing
- `pnpm --filter @stationery/shared test`
- `pnpm --filter @stationery/web test`
- `pnpm --filter @stationery/api test` *(fails: better-sqlite3 native binding unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e55c5bf994832e9d0db8b68a9bfb71